### PR TITLE
altered makeWorld to accept world name string

### DIFF
--- a/PythonTools/MBuild.py
+++ b/PythonTools/MBuild.py
@@ -98,10 +98,9 @@ for option in options["Archivist"]:
 # makeWorld
 
 outFile.write('\n\n//create a world\n')
-outFile.write('shared_ptr<AbstractWorld> makeWorld(shared_ptr<ParametersTable> PT){\n')
+outFile.write('shared_ptr<AbstractWorld> makeWorld(shared_ptr<ParametersTable> PT, string worldType){\n')
 outFile.write('  shared_ptr<AbstractWorld> newWorld;\n')
 outFile.write('  bool found = false;\n')
-outFile.write('  string worldType = AbstractWorld::worldTypePL->get(PT);\n')
 for option in options["World"]:
 	outFile.write('  if (worldType == "'+option+'") {\n')
 	outFile.write('    newWorld = make_shared<'+option+'World>(PT);\n')

--- a/main.cpp
+++ b/main.cpp
@@ -77,7 +77,7 @@ int main(int argc, const char * argv[]) {
 	}
 
 	// make world uses WORLD-worldType to determine type of world
-	auto world = makeWorld(Parameters::root);
+	auto world = makeWorld(Parameters::root, AbstractWorld::worldTypePL->get(Parameters::root));
 	map<string, shared_ptr<Group>> groups;
 	shared_ptr<ParametersTable> PT;
 


### PR DESCRIPTION
This is a modification of the makeWorld signature, so that the worldType string source is no longer hardcoded to AbstractWorld::worldType, and can instead be passed as a second parameter. This is useful for metaworld workflows so makeWorld can be used to make different worlds from other configuration string sources.