### PR TITLE
Feature no delete build options lines

### DIFF
--- a/PythonTools/MBuild.py
+++ b/PythonTools/MBuild.py
@@ -55,22 +55,34 @@ file = open(args.buildOptions, 'r')
 pathToMABE=posixpath.dirname(args.buildOptions)
 if pathToMABE == "":
     pathToMABE = "./"
-lines = [line.rstrip('\n').split() for line in file if line.rstrip('\n').split() not in [[],['EOF']] ]
+lines = [line.rstrip('\n').split() for line in file if line.rstrip('\n').split() not in [['EOF']] ]
 file.close()
 
 options = {'World':[],'Genome':[],'Brain':[],'Optimizer':[],'Archivist':[],}
 currentOption = ""
 
-for line in lines:
+unrecognizedLinesFound=False
+for linenum,line in enumerate(lines):
+    if len(line)==0:
+        continue
+    linenum+=1 ## sane line numbering starting at 1
     if len(line) != 2:
         exit()
-    if line[0] == '%':
+    if line[0] == '%': ## set current category
         currentOption = line[1]
-    if line[0] == '*':
+    elif line[0] == '*': ## include and make default the module
         options[currentOption].append(line[1])
         options[currentOption][0], options[currentOption][len(options[currentOption])-1] = options[currentOption][len(options[currentOption])-1], options[currentOption][0]
-    if line[0] == '+':
+    elif line[0] == '+': ## include added modules
         options[currentOption].append(line[1])
+    elif line[0] == '-': ## ignore negated modules
+        continue
+    else: ## report errors on anything else
+        print("unrecognized line in buildoptions (line {0}): {1}".format(linenum,' '.join(line)))
+        unrecognizedLinesFound=True
+if unrecognizedLinesFound:
+    print("Errors found in biuldOptions.txt")
+    quit()
 
 
 if not('Default' in options['Archivist']):

--- a/buildOptions.txt
+++ b/buildOptions.txt
@@ -2,7 +2,6 @@
   - Memory
   - Berry
   - BerryPlus
-  - IPD
   - NumeralClassifier
   - SOF
   * Test

--- a/buildOptions.txt
+++ b/buildOptions.txt
@@ -1,30 +1,30 @@
 % World
-  + Memory
-  * Berry
-  + BerryPlus
-  + IPD
-  + NumeralClassifier
-  + SOF
-  + Test
+  - Memory
+  - Berry
+  - BerryPlus
+  - IPD
+  - NumeralClassifier
+  - SOF
+  * Test
 
 % Genome
-  + Multi
+  - Multi
   * Circular
   
 % Brain
-  * Markov
+  - Markov
   + CGP
-  + LSTM
-  + ConstantValues
-  + GeneticPrograming
-  + Human
-  + IPD
-  + Wire
+  - LSTM
+  * ConstantValues
+  - GeneticPrograming
+  - Human
+  - IPD
+  - Wire
 	
 % Optimizer
   * Simple
 
 % Archivist
   * Default
-  + SSwD
-  + LODwAP
+  - SSwD
+  - LODwAP


### PR DESCRIPTION
Added the '-' flag to complement '+' so lines don't need to be deleted. This was done because I found it annoying having to traverse directories just to remember what things were called that I had deleted from the file. You can still delete lines if that suits your fancy.

I also improved commenting of buildOptions parsing and added error reporting along with line number tracking, so the user knows specifically where they messed up if they did.

Lastly, now that there is an official way to have lines for modules present but not added to the build, then I've restructured the file so all but a minimal selection test environment and example additional module are enabled by default. This results in a fast "does it build?" first experience for new users, instead of having to wait for an attempted complete build just to see an example run to see it all working.