### PR TITLE
fixes vs build error with zupply

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+Utilities/zupply/build
+Utilities/zupply/doc
+Utilities/zupply/examples
+Utilities/zupply/LICENSE
+Utilities/zupply/README.md
+Utilities/zupply/unittest
+Utilities/zupply/src/quickstart.cpp

--- a/Utilities/zupply.cpp
+++ b/Utilities/zupply.cpp
@@ -1,4 +1,5 @@
 // this is a "shortcut" for the zupply library
 // update the library with the following command
 // git subtree pull --prefix=Utilities/zupply/ --squash https://github.com/zhreshold/zupply master
+#define _ENABLE_ATOMIC_ALIGNMENT_FIX 1
 #include "zupply/src/zupply.cpp"

--- a/Utilities/zupply.h
+++ b/Utilities/zupply.h
@@ -1,4 +1,5 @@
 // this is a "shortcut" for the zupply library
 // update the library with the following command
 // git subtree pull --prefix=Utilities/zupply/ --squash https://github.com/zhreshold/zupply master
+#define _ENABLE_ATOMIC_ALIGNMENT_FIX 1
 #include "zupply/src/zupply.hpp"


### PR DESCRIPTION
VS produces an error when:
- cmakelists.txt files are present that should not be, so now they are .gitignored
- using <atomic> without a special VS define that says we know what we're doing