### PR TITLE
adds {{rep}} keyword to mq_conditions

### DIFF
--- a/pythonTools/mq.py
+++ b/pythonTools/mq.py
@@ -172,6 +172,7 @@ exceptions = []
 condition_sets = []
 condition_sets_skipped = []
 constantDefs = ''
+populationLoaderDefs = ''
 cfg_files = []
 other_files = []
 executable = "./mabe"
@@ -286,6 +287,8 @@ with open(args.file) as openfileobject:
                 for i in line[2:]:
                     newParameter += i + ' '
                 HPCC_parameters.append(newParameter[:-1])
+            if line[0] == "PLF":
+                populationLoaderDefs += '\n '+' '.join(line[2:])
 
 padSizeReps = len(str(lastRep))
 
@@ -490,6 +493,11 @@ if args.runTest:
         constantDefs = constantDefs.replace(match.group(), "GLOBAL-updates 2")
 for i in range(len(combinations)):
     for rep in reps:
+        if not args.runNo:
+            if (len(populationLoaderDefs)): ## if any have been specified, then create the file and dump specified to file
+                os.chdir(absLocalDir)
+                with open('population_loader.plf','w') as file:
+                    file.write(populationLoaderDefs+'\n')
         if args.runLocal or args.runTest:
             # turn cgf_files list into a space separated string
             cfg_files_str = ' '.join(cfg_files)
@@ -536,6 +544,8 @@ for i in range(len(combinations)):
                 shutil.copy(f, workDir)  # copy the settings files to scratch
             for f in other_files:
                 shutil.copy(f, workDir)  # copy other files to scratch
+            if (len(populationLoaderDefs)):
+                shutil.copy('population_loader.plf', workDir)
 
             # if the local conditions directory is not already here, make it
             if not(os.path.exists(conditionDirectoryName)):

--- a/pythonTools/mq_conditions.txt
+++ b/pythonTools/mq_conditions.txt
@@ -3,6 +3,8 @@
 # Lists must not contain white space (i.e. "1,2,3" OK, "1, 2, 3" Not OK)
 
 # REPS = [FIRST REP] [LAST REP]
+# if experiments are up to 3-digits, then start at 101. If up to 4-digits start at 1001, etc.
+# This convention solves sorting and zero-padding problems later.
 REPS = 101 103
 
 # Settings to override the config files, but will not be varied
@@ -11,27 +13,32 @@ REPS = 101 103
 
 # VAR = [SHORT NAME]	[REAL NAME]	[conditon1,condition2,etc.]
 # Short name is used in this file, and also determines output directory names
-VAR = TSK	WORLD_BERRY-taskSwitchingCost	1.0,3.0
-VAR = RF1	WORLD_BERRY-rewardForFood1	0.50,1.00
-VAR = RF2	WORLD_BERRY-rewardForFood2	0.50,0.75
+VAR = TSK	WORLD_BERRY-taskSwitchingCost
+VAR = RF1	WORLD_BERRY-rewardForFood1
+VAR = RF2	WORLD_BERRY-rewardForFood2
+
+# Alternatively to VAR/EXCEPT, conditions can achieve a similar effect and still respect EXCEPT declarations
+#CONDITIONS = TSK=1.0,3.0  RF1="some message here"  RF2=2,[1,2,3,4]
+#CONDITIONS = TSK=1.0      RF1=0.80
 
 # EXCEPT = [SHORT NAME]=[condition],[SHORT NAME]=[condition],etc.
 # If all name/condition pairs are met for any EXCEPT, then that combination will not be run.
 EXCEPT =  TSK=3.0  RF1=0.50
 #EXCEPT = TSK=3.0  RF2=0.75
 
-# Alternatively to VAR/EXCEPT, conditions can achieve a similar effect and still respect EXCEPT declarations
-#CONDITIONS = TSK=1.0,3.0  RF1="some message here"  RF2=2,[1,2,3,4]
-#CONDITIONS = TSK=1.0      RF1=0.80
-
-# If you use conditions, then it's not necessary to specify values for vars, like below
-#VAR = TSK  WORLD_BERRY-taskSwitchingCost
-
 # list of setting files (.cfg) which you want MABE to load with the -f option. files will be loaded in the order provided.
 SETTINGS = settings.cfg,settings_organism.cfg,settings_world.cfg
 
-# list of files used by MABE (i.e. maps, images, etc.)
+# list of files used by MABE (i.e. maps, images, etc.) and you can use rep replacement {{rep}} syntax
+# these files will be copied to the working directory if necessary
 #OTHERFILES = my_file.txt
+
+# a population_loader.plf file can be created using the contents here
+# be sure to set the -p GLOBAL-initPop population_loader.plf in CONSTANT definitions above
+#PLF = MASTER = 'LOD_organisms.csv'
+# or the following 2 lines with rep replacement works:
+#PLF = some_var = best 5 by ID from { 'LOD_organisms_{{rep}}.csv' }
+#PLF = MASTER = collapse some_var
 -----
 
 # JOBNAME will be appended before condition (C*) identifier - if "NONE" then job will have not JOBNAME


### PR DESCRIPTION
Allow {{rep}} syntax in mq_conditions files which are replaced with the current rep number. Useful for population loading / analysis use cases.