### PR TITLE
Enhance pop loader

### DIFF
--- a/Utilities/Loader.cpp
+++ b/Utilities/Loader.cpp
@@ -20,11 +20,7 @@ using std::cout;
 using std::endl;
 using zz::fs::Directory; // filesystem crawling
 
-std::vector<std::pair<long, std::unordered_map<std::string, std::string>>>
-Loader::load_population(const std::string &loader_file_name) {
-
-  tk_counter = 0;
-
+  std::string Loader::load_from_file(const std::string &loader_file_name){
   std::ifstream flines(loader_file_name);
   if (!flines.is_open()) {
     std::cout << " error: population loader file " << loader_file_name
@@ -36,8 +32,22 @@ Loader::load_population(const std::string &loader_file_name) {
 
   std::cout << "Creating population from " << loader_file_name << std::endl;
 
-  auto all_lines = clean_lines(flines);
+  return  clean_lines(flines);
 
+  }
+
+
+std::vector<std::pair<long, std::unordered_map<std::string, std::string>>>
+Loader::load_population(const std::string &loader_option) {
+
+  tk_counter = 0;
+
+  std::regex plf_file(R"(.*\.plf)");
+
+  auto all_lines = std::regex_match(loader_option, plf_file)
+                       ? load_from_file(loader_option)
+                       : loader_option;
+  
   all_lines = find_and_generate_all_files(all_lines);
 
   parse_all_commands(all_lines);

--- a/Utilities/Loader.h
+++ b/Utilities/Loader.h
@@ -79,6 +79,8 @@ private:
   std::vector<std::vector<long>> keyword_least(size_t, std::string,
                                                std::string);
   std::vector<std::vector<long>> keyword_any(size_t, std::string);
+  std::vector<std::vector<long>> keyword_match(std::string, std::string,
+                                               std::string);
 
   void print_organism(long); // strictly to debug all_organisms entries
 };

--- a/Utilities/Loader.h
+++ b/Utilities/Loader.h
@@ -41,6 +41,8 @@ private:
 
   // 	methods
 
+  std::string load_from_file(const std::string &);
+  
   std::vector<std::string>
       expand_files(std::string);// for user inputted wildcards
   std::pair<long, long>

--- a/Utilities/Parameters.cpp
+++ b/Utilities/Parameters.cpp
@@ -157,6 +157,9 @@ MASTER = default 100 # by default :)
 #some_var = greatest 5 by ID from { '*.csv' }
 #MASTER = collapse some_var
  
+# an example with exact match
+#MASTER = match ID where 3 from 'snapshot_organisms_0.csv' 
+
 # a convoluted example :P
 #another_var = greatest 5 by ID from { '*.csv' } 
 #still_another_var = greatest 2 by ID from { '*.csv' : least 10 by score_AVE from { */LOD_*.csv : */SSWD_*.csv } : '*/*.csv' } 

--- a/Utilities/Parameters.cpp
+++ b/Utilities/Parameters.cpp
@@ -500,7 +500,7 @@ Parameters::readParametersFile(std::string file_name) {
 	}
 
     {
-      std::regex name_value_pair(R"(^\s*(\w+)\s*=\s*(.+)\s*$)");
+      std::regex name_value_pair(R"(^\s*(\w+)\s*=\s*(\S?.*\S)\s*$)");
       std::smatch m;
       if (std::regex_match(line, m, name_value_pair)) {
         auto name = name_space_name + category_name + "-" + m[1].str();

--- a/Utilities/Parameters.h
+++ b/Utilities/Parameters.h
@@ -699,8 +699,9 @@ public:
       stringToValue(value_as_string, value);
       this->setParameter(name, value, _tableNameSpace, _saveOnFileWrite);
     } else if (parameterType == "string") {
-      std::string value;
-      stringToValue(value_as_string, value);
+      std::string value = value_as_string;
+	  // since there might be spaces in the value, can't call
+      //  stringToValue(value_as_string, value);
       this->setParameter(name, value, _tableNameSpace, _saveOnFileWrite);
     } else if (parameterType == "int") {
       int value;

--- a/main.cpp
+++ b/main.cpp
@@ -249,20 +249,10 @@ int main(int argc, const char *argv[]) {
 
     vector<shared_ptr<Organism>> population;
 
-    auto file_to_load= Global::initPopPL->get(PT);
-
+    auto file_to_load = Global::initPopPL->get(PT);
     Loader loader;
-    int population_size;
-    auto orgs_to_load =
-        load_value(file_to_load, population_size)
-            ? std::vector<std::pair<
-                  long, std::unordered_map<std::string, std::string>>>(
-                  population_size,
-                  make_pair(-2, std::unordered_map<std::string, std::string>()))
-
-            : loader.load_population(file_to_load);
-
-    population_size = orgs_to_load.size();
+    auto orgs_to_load = loader.load_population(file_to_load);
+    int population_size = orgs_to_load.size();
 
     // add population_size organisms which look like progenitor but could be
     // loaded from file

--- a/main.cpp
+++ b/main.cpp
@@ -253,7 +253,11 @@ int main(int argc, const char *argv[]) {
     Loader loader;
     auto orgs_to_load = loader.load_population(file_to_load);
     int population_size = orgs_to_load.size();
-
+	
+	if (!population_size) {
+		std::cout << "error: MASTER must contain at least one organism" << std::endl;
+		exit(1);
+	}
     // add population_size organisms which look like progenitor but could be
     // loaded from file
     for (auto &org : orgs_to_load) {


### PR DESCRIPTION
initPop can now optionally take a *.plf file as an argument, or a single line with plf syntax.

organsims can be chosen from disk where attribute values match exactly the provided value ( this value is treated as a string, to avoid problems like double precision, etc)

Note: main() will crap out if plf doesn't manage to load even a single org.
Note: values in settings files can now contain spaces, so long as the entire value is on a single line. 