### PR TITLE
Rewrite

### DIFF
--- a/Archivist/DefaultArchivist.cpp
+++ b/Archivist/DefaultArchivist.cpp
@@ -9,419 +9,553 @@
 //         github.com/Hintzelab/MABE/wiki/License
 
 #include "DefaultArchivist.h"
-using namespace std;
 
 ////// ARCHIVIST-outputMethod is actually set by Modules.h //////
-shared_ptr<ParameterLink<string>> DefaultArchivist::Arch_outputMethodStrPL = Parameters::register_parameter("ARCHIVIST-outputMethod", (string) "This_string_is_set_by_modules.h",
-	"This_string_is_set_by_modules.h");  // string parameter for outputMethod;
+std::shared_ptr<ParameterLink<std::string>> DefaultArchivist::Arch_outputMethodStrPL =
+    Parameters::register_parameter(
+        "ARCHIVIST-outputMethod", (std::string) "This_string_is_set_by_modules.h",
+        "This_string_is_set_by_modules.h"); // string parameter for
+                                            // outputMethod;
 ////// ARCHIVIST-outputMethod is actually set by Modules.h //////
 
-shared_ptr<ParameterLink<string>> DefaultArchivist::Arch_realtimeSequencePL = Parameters::register_parameter("ARCHIVIST_DEFAULT-realtimeSequence", (string) ":10",
-	"How often to write to realtime data files. (format: x = single value, x-y = x to y, x-y:z = x to y on x, :z = from 0 to updates on z, x:z = from x to 'updates' on z) e.g. '1-100:10, 200, 300:100'");
-shared_ptr<ParameterLink<string>> DefaultArchivist::SS_Arch_dataSequencePL = Parameters::register_parameter("ARCHIVIST_DEFAULT-snapshotDataSequence", (string) ":100",
-	"How often to save a realtime snapshot data file. (format: x = single value, x-y = x to y, x-y:z = x to y on x, :z = from 0 to updates on z, x:z = from x to 'updates' on z) e.g. '1-100:10, 200, 300:100'");
-shared_ptr<ParameterLink<string>> DefaultArchivist::SS_Arch_organismSequencePL = Parameters::register_parameter("ARCHIVIST_DEFAULT-snapshotOrganismsSequence", (string) ":1000",
-	"How often to save a realtime snapshot genome file. (format: x = single value, x-y = x to y, x-y:z = x to y on x, :z = from 0 to updates on z, x:z = from x to 'updates' on z) e.g. '1-100:10, 200, 300:100'");
+std::shared_ptr<ParameterLink<std::string>> DefaultArchivist::Arch_realtimeSequencePL =
+    Parameters::register_parameter(
+        "ARCHIVIST_DEFAULT-realtimeSequence", (std::string) ":10",
+        "How often to write to realtime data files. (format: x = single value, "
+        "x-y = x to y, x-y:z = x to y on x, :z = from 0 to updates on z, x:z = "
+        "from x to 'updates' on z) e.g. '1-100:10, 200, 300:100'");
+std::shared_ptr<ParameterLink<std::string>> DefaultArchivist::SS_Arch_dataSequencePL =
+    Parameters::register_parameter(
+        "ARCHIVIST_DEFAULT-snapshotDataSequence", (std::string) ":100",
+        "How often to save a realtime snapshot data file. (format: x = single "
+        "value, x-y = x to y, x-y:z = x to y on x, :z = from 0 to updates on "
+        "z, x:z = from x to 'updates' on z) e.g. '1-100:10, 200, 300:100'");
+std::shared_ptr<ParameterLink<std::string>> DefaultArchivist::SS_Arch_organismSequencePL =
+    Parameters::register_parameter(
+        "ARCHIVIST_DEFAULT-snapshotOrganismsSequence", (std::string) ":1000",
+        "How often to save a realtime snapshot genome file. (format: x = "
+        "single value, x-y = x to y, x-y:z = x to y on x, :z = from 0 to "
+        "updates on z, x:z = from x to 'updates' on z) e.g. '1-100:10, 200, "
+        "300:100'");
 
-shared_ptr<ParameterLink<bool>> DefaultArchivist::Arch_writePopFilePL = Parameters::register_parameter("ARCHIVIST_DEFAULT-writePopFile", true, "Save data to average file?");
-shared_ptr<ParameterLink<bool>> DefaultArchivist::Arch_writeMaxFilePL = Parameters::register_parameter("ARCHIVIST_DEFAULT-writeMaxFile", true, "Save data to Max file?");
-shared_ptr<ParameterLink<string>> DefaultArchivist::Arch_DefaultPopFileColumnNamesPL = Parameters::register_parameter("ARCHIVIST_DEFAULT-popFileColumns", (string) "[]",
-	"data to be saved into average file (must be values that can generate an average). If empty, MABE will try to figure it out");
+std::shared_ptr<ParameterLink<bool>> DefaultArchivist::Arch_writePopFilePL =
+    Parameters::register_parameter("ARCHIVIST_DEFAULT-writePopFile", true,
+                                   "Save data to average file?");
+std::shared_ptr<ParameterLink<bool>> DefaultArchivist::Arch_writeMaxFilePL =
+    Parameters::register_parameter("ARCHIVIST_DEFAULT-writeMaxFile", true,
+                                   "Save data to Max file?");
+std::shared_ptr<ParameterLink<std::string>>
+    DefaultArchivist::Arch_DefaultPopFileColumnNamesPL =
+        Parameters::register_parameter(
+            "ARCHIVIST_DEFAULT-popFileColumns", (std::string) "[]",
+            "data to be saved into average file (must be values that can "
+            "generate an average). If empty, MABE will try to figure it out");
 
-shared_ptr<ParameterLink<string>> DefaultArchivist::Arch_FilePrefixPL = Parameters::register_parameter("ARCHIVIST_DEFAULT-filePrefix", (string) "NONE", "prefix for files saved by this archivst. \"NONE\" indicates no prefix.");
-shared_ptr<ParameterLink<bool>> DefaultArchivist::SS_Arch_writeDataFilesPL = Parameters::register_parameter("ARCHIVIST_DEFAULT-writeSnapshotDataFiles", false,
-	"if true, snapshot data files will be written (with all non genome data for entire population)");
-shared_ptr<ParameterLink<bool>> DefaultArchivist::SS_Arch_writeOrganismsFilesPL = Parameters::register_parameter("ARCHIVIST_DEFAULT-writeSnapshotOrganismsFiles", false, "if true, snapshot organisms files will be written (with all organisms for entire population)");
+std::shared_ptr<ParameterLink<std::string>> DefaultArchivist::Arch_FilePrefixPL =
+    Parameters::register_parameter("ARCHIVIST_DEFAULT-filePrefix",
+                                   (std::string) "NONE", "prefix for files saved by "
+                                                    "this archivst. \"NONE\" "
+                                                    "indicates no prefix.");
+std::shared_ptr<ParameterLink<bool>> DefaultArchivist::SS_Arch_writeDataFilesPL =
+    Parameters::register_parameter("ARCHIVIST_DEFAULT-writeSnapshotDataFiles",
+                                   false, "if true, snapshot data files will "
+                                          "be written (with all non genome "
+                                          "data for entire population)");
+std::shared_ptr<ParameterLink<bool>>
+    DefaultArchivist::SS_Arch_writeOrganismsFilesPL =
+        Parameters::register_parameter(
+            "ARCHIVIST_DEFAULT-writeSnapshotOrganismsFiles", false,
+            "if true, snapshot organisms files will be written (with all "
+            "organisms for entire population)");
 
-DefaultArchivist::DefaultArchivist(shared_ptr<ParametersTable> _PT, string _groupPrefix) :
-	PT(_PT), groupPrefix(_groupPrefix) {
+DefaultArchivist::DefaultArchivist(std::shared_ptr<ParametersTable> _PT,
+                                   std::string _groupPrefix)
+    : PT(_PT), groupPrefix(_groupPrefix) {
 
-	writePopFile = Arch_writePopFilePL->get(PT);
-	writeMaxFile = Arch_writeMaxFilePL->get(PT);
+  writePopFile = Arch_writePopFilePL->get(PT);
+  writeMaxFile = Arch_writeMaxFilePL->get(PT);
 
-	PopFileName = (groupPrefix == "") ? "pop.csv" : groupPrefix.substr(0, groupPrefix.size()-2) + "__pop.csv";
-	PopFileName = (Arch_FilePrefixPL->get(PT) == "NONE") ? PopFileName : Arch_FilePrefixPL->get(PT) + PopFileName;
+  PopFileName =
+      (groupPrefix == "")
+          ? "pop.csv"
+          : groupPrefix.substr(0, groupPrefix.size() - 2) + "__pop.csv";
+  PopFileName = (Arch_FilePrefixPL->get(PT) == "NONE")
+                    ? PopFileName
+                    : Arch_FilePrefixPL->get(PT) + PopFileName;
 
-	MaxFileName = (groupPrefix == "") ? "max.csv" : groupPrefix.substr(0, groupPrefix.size() - 2) + "__max.csv";
-	MaxFileName = (Arch_FilePrefixPL->get(PT) == "NONE") ? MaxFileName : Arch_FilePrefixPL->get(PT) + MaxFileName;
+  MaxFileName =
+      (groupPrefix == "")
+          ? "max.csv"
+          : groupPrefix.substr(0, groupPrefix.size() - 2) + "__max.csv";
+  MaxFileName = (Arch_FilePrefixPL->get(PT) == "NONE")
+                    ? MaxFileName
+                    : Arch_FilePrefixPL->get(PT) + MaxFileName;
 
-	PopFileColumnNames = Arch_DefaultPopFileColumnNamesPL->get(PT);
+  PopFileColumnNames = Arch_DefaultPopFileColumnNamesPL->get(PT);
 
-	DataFilePrefix = (groupPrefix == "") ? "snapshot_data" : groupPrefix.substr(0, groupPrefix.size() - 2) + "__" + "snapshot_data";
-	DataFilePrefix = (Arch_FilePrefixPL->get(PT) == "NONE") ? DataFilePrefix : Arch_FilePrefixPL->get(PT) + DataFilePrefix;
+  DataFilePrefix = (groupPrefix == "")
+                       ? "snapshot_data"
+                       : groupPrefix.substr(0, groupPrefix.size() - 2) + "__" +
+                             "snapshot_data";
+  DataFilePrefix = (Arch_FilePrefixPL->get(PT) == "NONE")
+                       ? DataFilePrefix
+                       : Arch_FilePrefixPL->get(PT) + DataFilePrefix;
 
-	OrganismFilePrefix = (groupPrefix == "") ? "snapshot_organisms" : groupPrefix.substr(0, groupPrefix.size() - 2) + "__" + "snapshot_organisms";
-	OrganismFilePrefix = (Arch_FilePrefixPL->get(PT) == "NONE") ? OrganismFilePrefix : Arch_FilePrefixPL->get(PT) + OrganismFilePrefix;
+  OrganismFilePrefix = (groupPrefix == "")
+                           ? "snapshot_organisms"
+                           : groupPrefix.substr(0, groupPrefix.size() - 2) +
+                                 "__" + "snapshot_organisms";
+  OrganismFilePrefix = (Arch_FilePrefixPL->get(PT) == "NONE")
+                           ? OrganismFilePrefix
+                           : Arch_FilePrefixPL->get(PT) + OrganismFilePrefix;
 
-	writeSnapshotDataFiles = SS_Arch_writeDataFilesPL->get(PT);
-	writeSnapshotGenomeFiles = SS_Arch_writeOrganismsFilesPL->get(PT);
+  writeSnapshotDataFiles = SS_Arch_writeDataFilesPL->get(PT);
+  writeSnapshotGenomeFiles = SS_Arch_writeOrganismsFilesPL->get(PT);
 
-	realtimeSequence.push_back(0);
-	realtimeDataSequence.push_back(0);
-	realtimeOrganismSequence.push_back(0);
+  realtimeSequence.push_back(0);
+  realtimeDataSequence.push_back(0);
+  realtimeOrganismSequence.push_back(0);
 
-	if (writePopFile != false || writeMaxFile != false) {
-		string realtimeSequenceStr = Arch_realtimeSequencePL->get(PT);
-		realtimeSequence.clear();
-		realtimeSequence = seq(realtimeSequenceStr, Global::updatesPL->get(), true);
-		if (realtimeSequence.size() == 0) {
-			cout << "unable to translate ARCHIVIST_DEFAULT-realtimeSequence \"" << realtimeSequenceStr << "\".\nExiting." << endl;
-			exit(1);
-		}
-	}
+  if (writePopFile != false || writeMaxFile != false) {
+    std::string realtimeSequenceStr = Arch_realtimeSequencePL->get(PT);
+    realtimeSequence.clear();
+    realtimeSequence = seq(realtimeSequenceStr, Global::updatesPL->get(), true);
+    if (realtimeSequence.size() == 0) {
+      std::cout << "unable to translate ARCHIVIST_DEFAULT-realtimeSequence \""
+           << realtimeSequenceStr << "\".\nExiting." << std::endl;
+      exit(1);
+    }
+  }
 
-	if (writeSnapshotDataFiles != false) {
-		string dataSequenceStr = SS_Arch_dataSequencePL->get(PT);
-		realtimeDataSequence.clear();
-		realtimeDataSequence = seq(dataSequenceStr, Global::updatesPL->get(), true);
-		if (realtimeDataSequence.size() == 0) {
-			cout << "unable to translate ARCHIVIST_DEFAULT-snapshotDataSequence \"" << dataSequenceStr << "\".\nExiting." << endl;
-			exit(1);
-		}
-	}
+  if (writeSnapshotDataFiles != false) {
+    std::string dataSequenceStr = SS_Arch_dataSequencePL->get(PT);
+    realtimeDataSequence.clear();
+    realtimeDataSequence = seq(dataSequenceStr, Global::updatesPL->get(), true);
+    if (realtimeDataSequence.size() == 0) {
+      std::cout << "unable to translate ARCHIVIST_DEFAULT-snapshotDataSequence \""
+           << dataSequenceStr << "\".\nExiting." << std::endl;
+      exit(1);
+    }
+  }
 
-	if (writeSnapshotGenomeFiles != false) {
-		string organismIntervalStr = SS_Arch_organismSequencePL->get(PT);
-		realtimeOrganismSequence.clear();
-		realtimeOrganismSequence = seq(organismIntervalStr, Global::updatesPL->get(), true);
-		if (realtimeOrganismSequence.size() == 0) {
-			cout << "unable to translate ARCHIVIST_DEFAULT-snapshotOrganismsSequence \"" << organismIntervalStr << "\".\nExiting." << endl;
-			exit(1);
-		}
-	}
+  if (writeSnapshotGenomeFiles != false) {
+    std::string organismIntervalStr = SS_Arch_organismSequencePL->get(PT);
+    realtimeOrganismSequence.clear();
+    realtimeOrganismSequence =
+        seq(organismIntervalStr, Global::updatesPL->get(), true);
+    if (realtimeOrganismSequence.size() == 0) {
+      std::cout << "unable to translate ARCHIVIST_DEFAULT-snapshotOrganismsSequence "
+              "\""
+           << organismIntervalStr << "\".\nExiting." << std::endl;
+      exit(1);
+    }
+  }
 
-	realtimeSequenceIndex = 0;
-	realtimeDataSeqIndex = 0;
-	realtimeOrganismSeqIndex = 0;
+  realtimeSequenceIndex = 0;
+  realtimeDataSeqIndex = 0;
+  realtimeOrganismSeqIndex = 0;
 
-	finished = false;
+  finished = false;
 }
 
-DefaultArchivist::DefaultArchivist(vector<string> popFileColumns, shared_ptr<Abstract_MTree> _maxFormula, shared_ptr<ParametersTable> _PT, string _groupPrefix) :
-	DefaultArchivist(_PT, _groupPrefix) {
-	convertCSVListToVector(PopFileColumnNames, DefaultPopFileColumns);
-	maxFormula = _maxFormula;
-	if (DefaultPopFileColumns.size() <= 0) {
-		DefaultPopFileColumns = popFileColumns;
-	}
-	for (auto key : DefaultPopFileColumns) {
-		if (key == "update") {
-			uniqueColumnNameToOutputBehaviors[key] = 0;
-			continue;
-		}
+DefaultArchivist::DefaultArchivist(std::vector<std::string> popFileColumns,
+                                   std::shared_ptr<Abstract_MTree> _maxFormula,
+                                   std::shared_ptr<ParametersTable> _PT,
+                                   std::string _groupPrefix)
+    : DefaultArchivist(_PT, _groupPrefix) {
+  convertCSVListToVector(PopFileColumnNames, DefaultPopFileColumns);
+  maxFormula = _maxFormula;
+  if (DefaultPopFileColumns.size() <= 0) {
+    DefaultPopFileColumns = popFileColumns;
+  }
+  for (auto key : DefaultPopFileColumns) {
+    if (key == "update") {
+      uniqueColumnNameToOutputBehaviors[key] = 0;
+      continue;
+    }
 
-		// Now check to see if key ends in an '_' and a known output method (from DataMap i.e. AVE, PROD, etc.)
-		size_t seperatorCharPos = key.find_last_of('_');
-		if (seperatorCharPos != string::npos && DataMap::knownOutputBehaviors.find(key.substr(seperatorCharPos + 1)) != DataMap::knownOutputBehaviors.end()) { // if there is an '&'
-			// if it does end in a known output method then add this method to the uiqueColumnNameToOutputBehaviors map for that key
-																																							   //key[seperatorCharPos] = '_';
-			if (uniqueColumnNameToOutputBehaviors.find(key.substr(0, seperatorCharPos)) == uniqueColumnNameToOutputBehaviors.end()) { // if key not in map
-				uniqueColumnNameToOutputBehaviors[key.substr(0, seperatorCharPos)] = DataMap::knownOutputBehaviors[key.substr(seperatorCharPos + 1)];
-				//cout << "set behavior: " << key.substr(seperatorCharPos + 1) << " to " << key.substr(0, seperatorCharPos);
-			}
-			else { // key already in map
-				uniqueColumnNameToOutputBehaviors[key.substr(0, seperatorCharPos)] = uniqueColumnNameToOutputBehaviors[key.substr(0, seperatorCharPos)] | DataMap::knownOutputBehaviors[key.substr(seperatorCharPos + 1)];
-				//cout << "added behavior: " << key.substr(seperatorCharPos + 1) << " to " << key.substr(0, seperatorCharPos);
-			}
-		}
-		else { // add key normally, because it has no special flags specified
-			if (uniqueColumnNameToOutputBehaviors.find(key) == uniqueColumnNameToOutputBehaviors.end()) {
-				uniqueColumnNameToOutputBehaviors[key] = DataMap::AVE;
-			}
-			else {
-				uniqueColumnNameToOutputBehaviors[key] |= DataMap::AVE;
-			}
-		}
-	}
+    // Now check to see if key ends in an '_' and a known output method (from
+    // DataMap i.e. AVE, PROD, etc.)
+    size_t seperatorCharPos = key.find_last_of('_');
+    if (seperatorCharPos != std::string::npos &&
+        DataMap::knownOutputBehaviors.find(key.substr(seperatorCharPos + 1)) !=
+            DataMap::knownOutputBehaviors.end()) { // if there is an '&'
+      // if it does end in a known output method then add this method to the
+      // uiqueColumnNameToOutputBehaviors map for that key
+      // key[seperatorCharPos] = '_';
+      if (uniqueColumnNameToOutputBehaviors.find(
+              key.substr(0, seperatorCharPos)) ==
+          uniqueColumnNameToOutputBehaviors.end()) { // if key not in map
+        uniqueColumnNameToOutputBehaviors[key.substr(0, seperatorCharPos)] =
+            DataMap::knownOutputBehaviors[key.substr(seperatorCharPos + 1)];
+        // std::cout << "set behavior: " << key.substr(seperatorCharPos + 1) << " to
+        // " << key.substr(0, seperatorCharPos);
+      } else { // key already in map
+        uniqueColumnNameToOutputBehaviors[key.substr(0, seperatorCharPos)] =
+            uniqueColumnNameToOutputBehaviors[key.substr(0, seperatorCharPos)] |
+            DataMap::knownOutputBehaviors[key.substr(seperatorCharPos + 1)];
+        // std::cout << "added behavior: " << key.substr(seperatorCharPos + 1) << "
+        // to " << key.substr(0, seperatorCharPos);
+      }
+    } else { // add key normally, because it has no special flags specified
+      if (uniqueColumnNameToOutputBehaviors.find(key) ==
+          uniqueColumnNameToOutputBehaviors.end()) {
+        uniqueColumnNameToOutputBehaviors[key] = DataMap::AVE;
+      } else {
+        uniqueColumnNameToOutputBehaviors[key] |= DataMap::AVE;
+      }
+    }
+  }
 }
 
-//save Max and pop file data
-//keys named all* will be converted to *. These should key for lists of values. These values will be averaged (used to average world repeats)
-void DefaultArchivist::writeRealTimeFiles(vector<shared_ptr<Organism>> &population) {
-	// write out population data
+// save Max and pop file data
+// keys named all* will be converted to *. These should key for lists of values.
+// These values will be averaged (used to average world repeats)
+void DefaultArchivist::writeRealTimeFiles(
+    std::vector<std::shared_ptr<Organism>> &population) {
+  // write out population data
 
-	if (writePopFile) {
-		double aveValue;
-		DataMap PopMap;
+  if (writePopFile) {
+    double aveValue;
+    DataMap PopMap;
 
+    // for (auto key : DefaultPopFileColumns) {
+    //	if (key != "update") {
+    for (auto kv : uniqueColumnNameToOutputBehaviors) {
+      if (kv.first != "update") {
+        aveValue = 0;
+        for (auto org : population) {
+          if (org->timeOfBirth < Global::update || saveNewOrgs) {
+            PopMap.append(kv.first, org->dataMap.getAverage(kv.first));
+          }
+        }
+      }
+      PopMap.setOutputBehavior(kv.first, kv.second);
+    }
+    PopMap.set("update", Global::update);
+    PopMap.writeToFile(
+        PopFileName, {}); // write the PopMap to file with empty list (save all)
+  }
 
-		//for (auto key : DefaultPopFileColumns) {
-		//	if (key != "update") {
-		for (auto kv : uniqueColumnNameToOutputBehaviors) {
-			if (kv.first != "update") {
-				aveValue = 0;
-				for (auto org : population) {
-					if (org->timeOfBirth < Global::update || saveNewOrgs) {
-						PopMap.append(kv.first, org->dataMap.getAverage(kv.first));
-					}
-				}
-			}
-			PopMap.setOutputBehavior(kv.first, kv.second);
-		}
-		PopMap.set("update", Global::update);
-		PopMap.writeToFile(PopFileName, { }); // write the PopMap to file with empty list (save all)
-
-	}
-
-	// write out Max data
-	if (writeMaxFile && maxFormula != nullptr) {
-		double bestScore;
-		shared_ptr<Organism> bestOrg;
-		for (size_t i = 0; i < population.size(); i++) {
-			if (population[i]->timeOfBirth < Global::update || saveNewOrgs) {
-				// find a valid score!
-				bestScore = maxFormula->eval(population[i]->dataMap, population[i]->PT)[0];
-				bestOrg = population[i];
-				i = population.size();
-			}
-		}
-		for (size_t i = 0; i < population.size(); i++) {
-			if (population[i]->timeOfBirth < Global::update || saveNewOrgs) {
-				double newScore = maxFormula->eval(population[i]->dataMap, population[i]->PT)[0];
-				if (newScore > bestScore) {
-					bestScore = newScore;
-					bestOrg = population[i];
-				}
-			}
-		}
-		bestOrg->dataMap.set("update", Global::update);
-		bestOrg->dataMap.writeToFile(MaxFileName);
-		bestOrg->dataMap.clear("update");
-	}
+  // write out Max data
+  if (writeMaxFile && maxFormula != nullptr) {
+    double bestScore;
+    std::shared_ptr<Organism> bestOrg;
+    for (size_t i = 0; i < population.size(); i++) {
+      if (population[i]->timeOfBirth < Global::update || saveNewOrgs) {
+        // find a valid score!
+        bestScore =
+            maxFormula->eval(population[i]->dataMap, population[i]->PT)[0];
+        bestOrg = population[i];
+        i = population.size();
+      }
+    }
+    for (size_t i = 0; i < population.size(); i++) {
+      if (population[i]->timeOfBirth < Global::update || saveNewOrgs) {
+        double newScore =
+            maxFormula->eval(population[i]->dataMap, population[i]->PT)[0];
+        if (newScore > bestScore) {
+          bestScore = newScore;
+          bestOrg = population[i];
+        }
+      }
+    }
+    bestOrg->dataMap.set("update", Global::update);
+    bestOrg->dataMap.writeToFile(MaxFileName);
+    bestOrg->dataMap.clear("update");
+  }
 }
 
-void DefaultArchivist::saveSnapshotData(vector<shared_ptr<Organism>> population) {
-	// write out data
-	string dataFileName = DataFilePrefix + "_" + to_string(Global::update) + ".csv";
-	if (files.find("snapshotData") == files.end()) {  // first make sure that the dataFile has been set up.
-			//population[0]->dataMap.Set("ancestors", "placeHolder");  // add ancestors so it will be in files (holds columns to be output for each file)
-		files["snapshotData"] = population[0]->dataMap.getKeys();		// get all keys from the valid orgs dataMap (all orgs should have the same keys in their dataMaps)
-		files["snapshotData"].push_back("snapshotAncestors");
-	}
+void DefaultArchivist::saveSnapshotData(
+    std::vector<std::shared_ptr<Organism>> population) {
+  // write out data
+  std::string dataFileName =
+      DataFilePrefix + "_" + std::to_string(Global::update) + ".csv";
+  if (files.find("snapshotData") ==
+      files.end()) { // first make sure that the dataFile has been set up.
+    // population[0]->dataMap.Set("ancestors", "placeHolder");  // add ancestors
+    // so it will be in files (holds columns to be output for each file)
+    files["snapshotData"] =
+        population[0]->dataMap.getKeys(); // get all keys from the valid orgs
+                                          // dataMap (all orgs should have the
+                                          // same keys in their dataMaps)
+    files["snapshotData"].push_back("snapshotAncestors");
+  }
 
-	// first, determine which orgs in population need to be saved.
-	vector<shared_ptr<Organism>> saveList;
-	int minBirthTime = population[0]->timeOfBirth; // time of birth of oldest org being saved in this update (init with random value)
+  // first, determine which orgs in population need to be saved.
+  std::vector<std::shared_ptr<Organism>> saveList;
+  int minBirthTime = population[0]->timeOfBirth; // time of birth of oldest org
+                                                 // being saved in this update
+                                                 // (init with random value)
 
-	if (saveNewOrgs) {
-		saveList = population;
-		for (auto org : population) {
-			minBirthTime = min(org->timeOfBirth, minBirthTime);
-		}
-	}
-	else {
-		for (auto org : population) {
-			if (org->timeOfBirth < Global::update) {
-				saveList.push_back(org);
-			}
-			minBirthTime = min(org->timeOfBirth, minBirthTime);
-		}
-	}
+  if (saveNewOrgs) {
+    saveList = population;
+    for (auto org : population) {
+      minBirthTime = std::min(org->timeOfBirth, minBirthTime);
+    }
+  } else {
+    for (auto org : population) {
+      if (org->timeOfBirth < Global::update) {
+        saveList.push_back(org);
+      }
+      minBirthTime = std::min(org->timeOfBirth, minBirthTime);
+    }
+  }
 
-	// now for each org, update ancestors and save if in saveList
-	for (auto org : population) {
+  // now for each org, update ancestors and save if in saveList
+  for (auto org : population) {
 
-		//cout << "---------------\n now looking at: " << org->ID << endl;
-		//cout << "  with parents List (" << org->parents.size() << "): ";
-		//for (auto a : org->parents) {
-		//	cout << a->ID << "  ";
-		//}
-		//cout << endl;
+    // std::cout << "---------------\n now looking at: " << org->ID << std::endl;
+    // std::cout << "  with parents List (" << org->parents.size() << "): ";
+    // for (auto a : org->parents) {
+    //	std::cout << a->ID << "  ";
+    //}
+    // std::cout << std::endl;
 
+    if (org->snapshotAncestors.size() != 1 ||
+        org->snapshotAncestors.find(org->ID) == org->snapshotAncestors.end()) {
+      // if this org does not only contain only itself in snapshotAncestors then
+      // it has not been saved before.
+      // we must confirm that snapshotAncestors is correct because things may
+      // have changed while we were not looking
+      // this process does 2 things:
+      // a) if this org is being saved then it makes sure it's up to date
+      // b) it makes sure that it's ancestor list is correct so that it's
+      // offspring will pass on the correct ancestor info.
+      //
+      // How does it work? (good question)
+      // get a checklist of parents of the current org
+      // for each parent, if they are going to be saved in this update, yay, we
+      // can just assign their ID to the ancestor list
+      // ... if they are not going to be saved then we need to check their
+      // ancestors to see if they are going to be saved,
+      // unless they are atleast as old as the oldest org being saved to this
+      // file.
+      // if they are at least as old as the oldest org being saved to this file
+      // then we can simply append their ancestors
 
-		if (org->snapshotAncestors.size() != 1 || org->snapshotAncestors.find(org->ID) == org->snapshotAncestors.end()) {
-			// if this org does not only contain only itself in snapshotAncestors then it has not been saved before.
-			// we must confirm that snapshotAncestors is correct because things may have changed while we were not looking
-			// this process does 2 things:
-			// a) if this org is being saved then it makes sure it's up to date
-			// b) it makes sure that it's ancestor list is correct so that it's offspring will pass on the correct ancestor info.
-			//
-			// How does it work? (good question)
-			// get a checklist of parents of the current org
-			// for each parent, if they are going to be saved in this update, yay, we can just assign their ID to the ancestor list
-			// ... if they are not going to be saved then we need to check their ancestors to see if they are going to be saved,
-			// unless they are atleast as old as the oldest org being saved to this file.
-			// if they are at least as old as the oldest org being saved to this file then we can simply append their ancestors
+      org->snapshotAncestors.clear();
+      std::vector<std::shared_ptr<Organism>> parentCheckList = org->parents;
 
-			org->snapshotAncestors.clear();
-			vector<shared_ptr<Organism>> parentCheckList = org->parents;
+      while (parentCheckList.size() > 0) {
+        auto parent = parentCheckList.back(); // this is "this parent"
+        parentCheckList.pop_back(); // remove this parent from checklist
 
-			while (parentCheckList.size() > 0) {
-				auto parent = parentCheckList.back(); // this is "this parent"
-				parentCheckList.pop_back(); // remove this parent from checklist
+        // std::cout << "\n org: " << org->ID << " parent: " << parent->ID << std::endl;
+        if (find(saveList.begin(), saveList.end(), parent) !=
+            saveList.end()) { // if this parent is being saved, they will serve
+                              // as an ancestor
+          org->snapshotAncestors.insert(parent->ID);
+        } else { // this parent is not being saved
+          if (parent->timeOfBirth < minBirthTime ||
+              (parent->snapshotAncestors.size() == 1 &&
+               parent->snapshotAncestors.find(parent->ID) !=
+                   parent->snapshotAncestors.end())) {
+            // if this parent is old enough that it can not have a parent in the
+            // save list (and is not in save list),
+            // or this parent has self in it's ancestor list (i.e. it has
+            // already been saved to another file),
+            // copy ancestors from this parent
+            // std::cout << "getting ancestors for " << org->ID << " parent " <<
+            // parent->ID << " is old enough or has self as ancestor..." <<
+            // std::endl;
+            for (auto ancestorID : parent->snapshotAncestors) {
+              // std::cout << "adding from parent " << parent->ID << " ancestor " <<
+              // ancestorID << std::endl;
+              org->snapshotAncestors.insert(ancestorID);
+            }
+          } else { // this parent not old enough (see if above), add this
+                   // parents parents to check list (we need to keep looking)
+            for (auto p : parent->parents) {
+              parentCheckList.push_back(p);
+            }
+          }
+        }
+      }
 
-				//cout << "\n org: " << org->ID << " parent: " << parent->ID << endl;
-				if (find(saveList.begin(), saveList.end(), parent) != saveList.end()) { // if this parent is being saved, they will serve as an ancestor
-					org->snapshotAncestors.insert(parent->ID);
-				}
-				else { // this parent is not being saved
-					if (parent->timeOfBirth < minBirthTime || (parent->snapshotAncestors.size() == 1 && parent->snapshotAncestors.find(parent->ID) != parent->snapshotAncestors.end())) {
-						// if this parent is old enough that it can not have a parent in the save list (and is not in save list),
-						// or this parent has self in it's ancestor list (i.e. it has already been saved to another file),
-						// copy ancestors from this parent
-						//cout << "getting ancestors for " << org->ID << " parent " << parent->ID << " is old enough or has self as ancestor..." << endl;
-						for (auto ancestorID : parent->snapshotAncestors) {
-							//cout << "adding from parent " << parent->ID << " ancestor " << ancestorID << endl;
-							org->snapshotAncestors.insert(ancestorID);
-						}
-					}
-					else { // this parent not old enough (see if above), add this parents parents to check list (we need to keep looking)
-						for (auto p : parent->parents) {
-							parentCheckList.push_back(p);
-						}
-					}
-				}
-			}
+      /* // uncomment to see updated ancesstors list
+      std::cout << "  new snapshotAncestors List: ";
+      for (auto a : org->snapshotAncestors) {
+              std::cout << a << "  ";
+      }
+      std::cout << std::endl;
+      */
 
-			/* // uncomment to see updated ancesstors list
-			cout << "  new snapshotAncestors List: ";
-			for (auto a : org->snapshotAncestors) {
-				cout << a << "  ";
-			}
-			cout << endl;
-			*/
+    } else {                                    // org has self for ancestor
+      if (org->timeOfBirth >= Global::update) { // if this is a new org...
+        std::cout << "  WARRNING :: in DefaultArchivist::saveSnapshotData(), found "
+                "new org (age < 1) with self as ancestor (with ID: "
+             << org->ID
+             << "... this will result in a new root to the phylogony tree!"
+             << std::endl;
+        if (saveNewOrgs) {
+          std::cout << "    this org is being saved" << std::endl;
+        } else {
+          std::cout << "    this org is not being saved (this may be very bad...)"
+               << std::endl;
+        }
+      }
+    }
+    // now that we know that ancestor list is good for this org...
+    if (org->timeOfBirth < Global::update || saveNewOrgs) {
+      // std::cout << "  is being saved" << std::endl;
+      for (auto ancestorID : org->snapshotAncestors) {
+        // std::cout << org->ID << " adding ancestor " << ancestorID << " to dataMap"
+        // << std::endl;
+        org->dataMap.append("snapshotAncestors", ancestorID);
+      }
+      org->dataMap.setOutputBehavior("snapshotAncestors", DataMap::LIST);
 
-		}
-		else { // org has self for ancestor
-			if (org->timeOfBirth >= Global::update) { // if this is a new org...
-				cout << "  WARRNING :: in DefaultArchivist::saveSnapshotData(), found new org (age < 1) with self as ancestor (with ID: " << org->ID << "... this will result in a new root to the phylogony tree!" << endl;
-				if (saveNewOrgs) {
-					cout << "    this org is being saved" << endl;
-				}
-				else {
-					cout << "    this org is not being saved (this may be very bad...)" << endl;
-				}
-			}
-		}
-		// now that we know that ancestor list is good for this org...
-		if (org->timeOfBirth < Global::update || saveNewOrgs) {
-			//cout << "  is being saved" << endl;
-			for (auto ancestorID : org->snapshotAncestors) {
-				//cout << org->ID << " adding ancestor " << ancestorID << " to dataMap" << endl;
-				org->dataMap.append("snapshotAncestors", ancestorID);
-			}
-			org->dataMap.setOutputBehavior("snapshotAncestors", DataMap::LIST);
-
-			org->snapshotAncestors.clear();  // now that we have saved the ancestor data, set ancestors to self (so that others will inherit correctly)
-			org->snapshotAncestors.insert(org->ID);
-			org->dataMap.set("update", Global::update);
-			org->dataMap.setOutputBehavior("update", DataMap::FIRST);
-			org->dataMap.writeToFile(dataFileName, files["snapshotData"]);  // append new data to the file
-			org->dataMap.clear("snapshotAncestors");
-			org->dataMap.clear("update");
-		}
-	}
-	FileManager::closeFile(dataFileName); // since this is a snapshot, we will not be writting to this file again.
+      org->snapshotAncestors.clear(); // now that we have saved the ancestor
+                                      // data, set ancestors to self (so that
+                                      // others will inherit correctly)
+      org->snapshotAncestors.insert(org->ID);
+      org->dataMap.set("update", Global::update);
+      org->dataMap.setOutputBehavior("update", DataMap::FIRST);
+      org->dataMap.writeToFile(
+          dataFileName, files["snapshotData"]); // append new data to the file
+      org->dataMap.clear("snapshotAncestors");
+      org->dataMap.clear("update");
+    }
+  }
+  FileManager::closeFile(dataFileName); // since this is a snapshot, we will not
+                                        // be writting to this file again.
 }
 
-void DefaultArchivist::saveSnapshotOrganisms(vector<shared_ptr<Organism>> population) {
-	// write out organims
-	string organismFileName = OrganismFilePrefix + "_" + to_string(Global::update) + ".csv";
+void DefaultArchivist::saveSnapshotOrganisms(
+    std::vector<std::shared_ptr<Organism>> population) {
+  // write out organims
+  std::string organismFileName =
+      OrganismFilePrefix + "_" + std::to_string(Global::update) + ".csv";
 
-	for (auto org : population) {
-		if (org->timeOfBirth < Global::update || saveNewOrgs) {
-			DataMap OrgMap;
-			OrgMap.set("ID", org->ID);
-			string tempName;
+  for (auto org : population) {
+    if (org->timeOfBirth < Global::update || saveNewOrgs) {
+      DataMap OrgMap;
+      OrgMap.set("ID", org->ID);
+      std::string tempName;
 
-			for (auto genome : org->genomes) {
-				tempName = "GENOME_" + genome.first;
-				OrgMap.merge(genome.second->serialize(tempName));
-			}
-			for (auto brain : org->brains) {
-				tempName = "BRAIN_" + brain.first;
-				OrgMap.merge(brain.second->serialize(tempName));
-			}
-			OrgMap.writeToFile(organismFileName); // append new data to the file
-		}
-	}
-	FileManager::closeFile(organismFileName); // since this is a snapshot, we will not be writting to this file again.
+      for (auto genome : org->genomes) {
+        tempName = "GENOME_" + genome.first;
+        OrgMap.merge(genome.second->serialize(tempName));
+      }
+      for (auto brain : org->brains) {
+        tempName = "BRAIN_" + brain.first;
+        OrgMap.merge(brain.second->serialize(tempName));
+      }
+      OrgMap.writeToFile(organismFileName); // append new data to the file
+    }
+  }
+  FileManager::closeFile(organismFileName); // since this is a snapshot, we will
+                                            // not be writting to this file
+                                            // again.
 }
 
 // save data and manage in memory data
 // return true if next save will be > updates + terminate after
-bool DefaultArchivist::archive(vector<shared_ptr<Organism>> population, int flush) {
+bool DefaultArchivist::archive(std::vector<std::shared_ptr<Organism>> population,
+                               int flush) {
 
-	if (finished) {
-		return finished;
-	}
-	if (flush != 1) {
-		if ((Global::update == realtimeSequence[realtimeSequenceIndex]) && (flush == 0)) {  // do not write files on flush - these organisms have not been evaluated!
-			writeRealTimeFiles(population);  // write to Max and Pop files
-			if (realtimeSequenceIndex + 1 < (int)realtimeSequence.size()) {
-				realtimeSequenceIndex++;
-			}
-		}
+  if (finished) {
+    return finished;
+  }
+  if (flush != 1) {
+    if ((Global::update == realtimeSequence[realtimeSequenceIndex]) &&
+        (flush == 0)) { // do not write files on flush - these organisms have
+                        // not been evaluated!
+      writeRealTimeFiles(population); // write to Max and Pop files
+      if (realtimeSequenceIndex + 1 < (int)realtimeSequence.size()) {
+        realtimeSequenceIndex++;
+      }
+    }
 
-		if ((Global::update == realtimeDataSequence[realtimeDataSeqIndex]) && (flush == 0) && writeSnapshotDataFiles) {  // do not write files on flush - these organisms have not been evaluated!
-			saveSnapshotData(population);
-			if (realtimeDataSeqIndex + 1 < (int)realtimeDataSequence.size()) {
-				realtimeDataSeqIndex++;
-			}
-		}
-		if ((Global::update == realtimeOrganismSequence[realtimeOrganismSeqIndex]) && (flush == 0) && writeSnapshotGenomeFiles) {  // do not write files on flush - these organisms have not been evaluated!
-			saveSnapshotOrganisms(population);
-			if (realtimeOrganismSeqIndex + 1 < (int)realtimeOrganismSequence.size()) {
-				realtimeOrganismSeqIndex++;
-			}
-		}
+    if ((Global::update == realtimeDataSequence[realtimeDataSeqIndex]) &&
+        (flush == 0) &&
+        writeSnapshotDataFiles) { // do not write files on flush - these
+                                  // organisms have not been evaluated!
+      saveSnapshotData(population);
+      if (realtimeDataSeqIndex + 1 < (int)realtimeDataSequence.size()) {
+        realtimeDataSeqIndex++;
+      }
+    }
+    if ((Global::update ==
+         realtimeOrganismSequence[realtimeOrganismSeqIndex]) &&
+        (flush == 0) &&
+        writeSnapshotGenomeFiles) { // do not write files on flush - these
+                                    // organisms have not been evaluated!
+      saveSnapshotOrganisms(population);
+      if (realtimeOrganismSeqIndex + 1 < (int)realtimeOrganismSequence.size()) {
+        realtimeOrganismSeqIndex++;
+      }
+    }
 
-		vector<shared_ptr<Organism>> toCheck;
-		unordered_set<shared_ptr<Organism>> checked;
-		int minBirthTime = population[0]->timeOfBirth; // time of birth of oldest org being saved in this update (init with random value)
+    std::vector<std::shared_ptr<Organism>> toCheck;
+    std::unordered_set<std::shared_ptr<Organism>> checked;
+    int minBirthTime =
+        population[0]->timeOfBirth; // time of birth of oldest org being saved
+                                    // in this update (init with random value)
 
-		for (auto org : population) {  // we don't need to worry about tracking parents or lineage, so we clear out this data every generation.
-			if (!writeSnapshotDataFiles) {
-				org->parents.clear();
-			}
-			else if (org->snapshotAncestors.find(org->ID) != org->snapshotAncestors.end()) { // if ancestors contains self, then this org has been saved and it's ancestor list has been collapsed
-				org->parents.clear();
-				checked.insert(org); // make a note, so we don't check this org later
-				minBirthTime = min(org->timeOfBirth, minBirthTime);
-			}
-			else { // org has not ever been saved to file...
-				toCheck.push_back(org); // we will need to check to see if we can do clean up related to this org
-				checked.insert(org); // make a note, so we don't check twice
-				minBirthTime = min(org->timeOfBirth, minBirthTime);
-			}
-		}
+    for (auto org :
+         population) { // we don't need to worry about tracking parents or
+                       // lineage, so we clear out this data every generation.
+      if (!writeSnapshotDataFiles) {
+        org->parents.clear();
+      } else if (org->snapshotAncestors.find(org->ID) !=
+                 org->snapshotAncestors.end()) { // if ancestors contains self,
+                                                 // then this org has been saved
+                                                 // and it's ancestor list has
+                                                 // been collapsed
+        org->parents.clear();
+        checked.insert(org); // make a note, so we don't check this org later
+        minBirthTime = std::min(org->timeOfBirth, minBirthTime);
+      } else {                  // org has not ever been saved to file...
+        toCheck.push_back(org); // we will need to check to see if we can do
+                                // clean up related to this org
+        checked.insert(org);    // make a note, so we don't check twice
+        minBirthTime = std::min(org->timeOfBirth, minBirthTime);
+      }
+    }
 
-		while (toCheck.size() > 0) {
-			auto org = toCheck.back();
-			toCheck.pop_back();
-			if (org->timeOfBirth < minBirthTime) { // no living org can be this orgs ancestor
-				org->parents.clear(); // we can safely release parents
-			}
-			else {
-				for (auto p : org->parents) { // we need to check parents (if any)
-					if (checked.find(p) == checked.end()) { // if parent is not already in checked list (i.e. either checked or going to be)
-						toCheck.push_back(p);
-						checked.insert(org); // make a note, so we don't check twice
-					}
-				}
-			}
-		}
-
-
-	}
-	// if we are at the end of the run
-	finished = Global::update >= Global::updatesPL->get();
-	return finished;
+    while (toCheck.size() > 0) {
+      auto org = toCheck.back();
+      toCheck.pop_back();
+      if (org->timeOfBirth <
+          minBirthTime) {     // no living org can be this orgs ancestor
+        org->parents.clear(); // we can safely release parents
+      } else {
+        for (auto p : org->parents) { // we need to check parents (if any)
+          if (checked.find(p) == checked.end()) { // if parent is not already in
+                                                  // checked list (i.e. either
+                                                  // checked or going to be)
+            toCheck.push_back(p);
+            checked.insert(org); // make a note, so we don't check twice
+          }
+        }
+      }
+    }
+  }
+  // if we are at the end of the run
+  finished = Global::update >= Global::updatesPL->get();
+  return finished;
 }
 
 bool DefaultArchivist::isDataUpdate(int checkUpdate) {
-	if (checkUpdate == -1) {
-		checkUpdate = Global::update;
-	}
-	bool check = find(realtimeSequence.begin(), realtimeSequence.end(), checkUpdate) != realtimeSequence.end();
-	check = check || find(realtimeDataSequence.begin(), realtimeDataSequence.end(), checkUpdate) != realtimeDataSequence.end();
-	return check;
+  if (checkUpdate == -1) {
+    checkUpdate = Global::update;
+  }
+  bool check = find(realtimeSequence.begin(), realtimeSequence.end(),
+                    checkUpdate) != realtimeSequence.end();
+  check = check ||
+          find(realtimeDataSequence.begin(), realtimeDataSequence.end(),
+               checkUpdate) != realtimeDataSequence.end();
+  return check;
 }
 
 bool DefaultArchivist::isOrganismUpdate(int checkUpdate) {
-	if (checkUpdate == -1) {
-		checkUpdate = Global::update;
-	}
-	bool check = find(realtimeOrganismSequence.begin(), realtimeOrganismSequence.end(), checkUpdate) != realtimeOrganismSequence.end();
-	return check;
+  if (checkUpdate == -1) {
+    checkUpdate = Global::update;
+  }
+  bool check =
+      find(realtimeOrganismSequence.begin(), realtimeOrganismSequence.end(),
+           checkUpdate) != realtimeOrganismSequence.end();
+  return check;
 }

--- a/Archivist/DefaultArchivist.cpp
+++ b/Archivist/DefaultArchivist.cpp
@@ -11,26 +11,28 @@
 #include "DefaultArchivist.h"
 
 ////// ARCHIVIST-outputMethod is actually set by Modules.h //////
-std::shared_ptr<ParameterLink<std::string>> DefaultArchivist::Arch_outputMethodStrPL =
-    Parameters::register_parameter(
-        "ARCHIVIST-outputMethod", (std::string) "This_string_is_set_by_modules.h",
+std::shared_ptr<ParameterLink<std::string>>
+    DefaultArchivist::Arch_outputMethodStrPL = Parameters::register_parameter(
+        "ARCHIVIST-outputMethod",
+        (std::string) "This_string_is_set_by_modules.h",
         "This_string_is_set_by_modules.h"); // string parameter for
                                             // outputMethod;
 ////// ARCHIVIST-outputMethod is actually set by Modules.h //////
 
-std::shared_ptr<ParameterLink<std::string>> DefaultArchivist::Arch_realtimeSequencePL =
-    Parameters::register_parameter(
+std::shared_ptr<ParameterLink<std::string>>
+    DefaultArchivist::Arch_realtimeSequencePL = Parameters::register_parameter(
         "ARCHIVIST_DEFAULT-realtimeSequence", (std::string) ":10",
         "How often to write to realtime data files. (format: x = single value, "
         "x-y = x to y, x-y:z = x to y on x, :z = from 0 to updates on z, x:z = "
         "from x to 'updates' on z) e.g. '1-100:10, 200, 300:100'");
-std::shared_ptr<ParameterLink<std::string>> DefaultArchivist::SS_Arch_dataSequencePL =
-    Parameters::register_parameter(
+std::shared_ptr<ParameterLink<std::string>>
+    DefaultArchivist::SS_Arch_dataSequencePL = Parameters::register_parameter(
         "ARCHIVIST_DEFAULT-snapshotDataSequence", (std::string) ":100",
         "How often to save a realtime snapshot data file. (format: x = single "
         "value, x-y = x to y, x-y:z = x to y on x, :z = from 0 to updates on "
         "z, x:z = from x to 'updates' on z) e.g. '1-100:10, 200, 300:100'");
-std::shared_ptr<ParameterLink<std::string>> DefaultArchivist::SS_Arch_organismSequencePL =
+std::shared_ptr<
+    ParameterLink<std::string>> DefaultArchivist::SS_Arch_organismSequencePL =
     Parameters::register_parameter(
         "ARCHIVIST_DEFAULT-snapshotOrganismsSequence", (std::string) ":1000",
         "How often to save a realtime snapshot genome file. (format: x = "
@@ -51,16 +53,19 @@ std::shared_ptr<ParameterLink<std::string>>
             "data to be saved into average file (must be values that can "
             "generate an average). If empty, MABE will try to figure it out");
 
-std::shared_ptr<ParameterLink<std::string>> DefaultArchivist::Arch_FilePrefixPL =
-    Parameters::register_parameter("ARCHIVIST_DEFAULT-filePrefix",
-                                   (std::string) "NONE", "prefix for files saved by "
-                                                    "this archivst. \"NONE\" "
-                                                    "indicates no prefix.");
-std::shared_ptr<ParameterLink<bool>> DefaultArchivist::SS_Arch_writeDataFilesPL =
-    Parameters::register_parameter("ARCHIVIST_DEFAULT-writeSnapshotDataFiles",
-                                   false, "if true, snapshot data files will "
-                                          "be written (with all non genome "
-                                          "data for entire population)");
+std::shared_ptr<ParameterLink<std::string>>
+    DefaultArchivist::Arch_FilePrefixPL =
+        Parameters::register_parameter("ARCHIVIST_DEFAULT-filePrefix",
+                                       (std::string) "NONE",
+                                       "prefix for files saved by "
+                                       "this archivst. \"NONE\" "
+                                       "indicates no prefix.");
+std::shared_ptr<ParameterLink<bool>>
+    DefaultArchivist::SS_Arch_writeDataFilesPL = Parameters::register_parameter(
+        "ARCHIVIST_DEFAULT-writeSnapshotDataFiles", false,
+        "if true, snapshot data files will "
+        "be written (with all non genome "
+        "data for entire population)");
 std::shared_ptr<ParameterLink<bool>>
     DefaultArchivist::SS_Arch_writeOrganismsFilesPL =
         Parameters::register_parameter(
@@ -122,7 +127,7 @@ DefaultArchivist::DefaultArchivist(std::shared_ptr<ParametersTable> _PT,
     realtimeSequence = seq(realtimeSequenceStr, Global::updatesPL->get(), true);
     if (realtimeSequence.size() == 0) {
       std::cout << "unable to translate ARCHIVIST_DEFAULT-realtimeSequence \""
-           << realtimeSequenceStr << "\".\nExiting." << std::endl;
+                << realtimeSequenceStr << "\".\nExiting." << std::endl;
       exit(1);
     }
   }
@@ -132,8 +137,9 @@ DefaultArchivist::DefaultArchivist(std::shared_ptr<ParametersTable> _PT,
     realtimeDataSequence.clear();
     realtimeDataSequence = seq(dataSequenceStr, Global::updatesPL->get(), true);
     if (realtimeDataSequence.size() == 0) {
-      std::cout << "unable to translate ARCHIVIST_DEFAULT-snapshotDataSequence \""
-           << dataSequenceStr << "\".\nExiting." << std::endl;
+      std::cout
+          << "unable to translate ARCHIVIST_DEFAULT-snapshotDataSequence \""
+          << dataSequenceStr << "\".\nExiting." << std::endl;
       exit(1);
     }
   }
@@ -144,9 +150,10 @@ DefaultArchivist::DefaultArchivist(std::shared_ptr<ParametersTable> _PT,
     realtimeOrganismSequence =
         seq(organismIntervalStr, Global::updatesPL->get(), true);
     if (realtimeOrganismSequence.size() == 0) {
-      std::cout << "unable to translate ARCHIVIST_DEFAULT-snapshotOrganismsSequence "
-              "\""
-           << organismIntervalStr << "\".\nExiting." << std::endl;
+      std::cout
+          << "unable to translate ARCHIVIST_DEFAULT-snapshotOrganismsSequence "
+             "\""
+          << organismIntervalStr << "\".\nExiting." << std::endl;
       exit(1);
     }
   }
@@ -188,13 +195,15 @@ DefaultArchivist::DefaultArchivist(std::vector<std::string> popFileColumns,
           uniqueColumnNameToOutputBehaviors.end()) { // if key not in map
         uniqueColumnNameToOutputBehaviors[key.substr(0, seperatorCharPos)] =
             DataMap::knownOutputBehaviors[key.substr(seperatorCharPos + 1)];
-        // std::cout << "set behavior: " << key.substr(seperatorCharPos + 1) << " to
+        // std::cout << "set behavior: " << key.substr(seperatorCharPos + 1) <<
+        // " to
         // " << key.substr(0, seperatorCharPos);
       } else { // key already in map
         uniqueColumnNameToOutputBehaviors[key.substr(0, seperatorCharPos)] =
             uniqueColumnNameToOutputBehaviors[key.substr(0, seperatorCharPos)] |
             DataMap::knownOutputBehaviors[key.substr(seperatorCharPos + 1)];
-        // std::cout << "added behavior: " << key.substr(seperatorCharPos + 1) << "
+        // std::cout << "added behavior: " << key.substr(seperatorCharPos + 1)
+        // << "
         // to " << key.substr(0, seperatorCharPos);
       }
     } else { // add key normally, because it has no special flags specified
@@ -305,7 +314,8 @@ void DefaultArchivist::saveSnapshotData(
   // now for each org, update ancestors and save if in saveList
   for (auto org : population) {
 
-    // std::cout << "---------------\n now looking at: " << org->ID << std::endl;
+    // std::cout << "---------------\n now looking at: " << org->ID <<
+    // std::endl;
     // std::cout << "  with parents List (" << org->parents.size() << "): ";
     // for (auto a : org->parents) {
     //	std::cout << a->ID << "  ";
@@ -341,7 +351,8 @@ void DefaultArchivist::saveSnapshotData(
         auto parent = parentCheckList.back(); // this is "this parent"
         parentCheckList.pop_back(); // remove this parent from checklist
 
-        // std::cout << "\n org: " << org->ID << " parent: " << parent->ID << std::endl;
+        // std::cout << "\n org: " << org->ID << " parent: " << parent->ID <<
+        // std::endl;
         if (find(saveList.begin(), saveList.end(), parent) !=
             saveList.end()) { // if this parent is being saved, they will serve
                               // as an ancestor
@@ -360,7 +371,8 @@ void DefaultArchivist::saveSnapshotData(
             // parent->ID << " is old enough or has self as ancestor..." <<
             // std::endl;
             for (auto ancestorID : parent->snapshotAncestors) {
-              // std::cout << "adding from parent " << parent->ID << " ancestor " <<
+              // std::cout << "adding from parent " << parent->ID << " ancestor
+              // " <<
               // ancestorID << std::endl;
               org->snapshotAncestors.insert(ancestorID);
             }
@@ -383,16 +395,18 @@ void DefaultArchivist::saveSnapshotData(
 
     } else {                                    // org has self for ancestor
       if (org->timeOfBirth >= Global::update) { // if this is a new org...
-        std::cout << "  WARRNING :: in DefaultArchivist::saveSnapshotData(), found "
-                "new org (age < 1) with self as ancestor (with ID: "
-             << org->ID
-             << "... this will result in a new root to the phylogony tree!"
-             << std::endl;
+        std::cout
+            << "  WARRNING :: in DefaultArchivist::saveSnapshotData(), found "
+               "new org (age < 1) with self as ancestor (with ID: "
+            << org->ID
+            << "... this will result in a new root to the phylogony tree!"
+            << std::endl;
         if (saveNewOrgs) {
           std::cout << "    this org is being saved" << std::endl;
         } else {
-          std::cout << "    this org is not being saved (this may be very bad...)"
-               << std::endl;
+          std::cout
+              << "    this org is not being saved (this may be very bad...)"
+              << std::endl;
         }
       }
     }
@@ -400,7 +414,8 @@ void DefaultArchivist::saveSnapshotData(
     if (org->timeOfBirth < Global::update || saveNewOrgs) {
       // std::cout << "  is being saved" << std::endl;
       for (auto ancestorID : org->snapshotAncestors) {
-        // std::cout << org->ID << " adding ancestor " << ancestorID << " to dataMap"
+        // std::cout << org->ID << " adding ancestor " << ancestorID << " to
+        // dataMap"
         // << std::endl;
         org->dataMap.append("snapshotAncestors", ancestorID);
       }
@@ -452,8 +467,8 @@ void DefaultArchivist::saveSnapshotOrganisms(
 
 // save data and manage in memory data
 // return true if next save will be > updates + terminate after
-bool DefaultArchivist::archive(std::vector<std::shared_ptr<Organism>> population,
-                               int flush) {
+bool DefaultArchivist::archive(
+    std::vector<std::shared_ptr<Organism>> population, int flush) {
 
   if (finished) {
     return finished;

--- a/Archivist/DefaultArchivist.h
+++ b/Archivist/DefaultArchivist.h
@@ -21,82 +21,100 @@
 #include "../Organism/Organism.h"
 #include "../Utilities/MTree.h"
 
-using namespace std;
-
 class DefaultArchivist {
- public:
+public:
+  static std::shared_ptr<ParameterLink<std::string>>
+      Arch_outputMethodStrPL; // string parameter for outputMethod;
 
-	static shared_ptr<ParameterLink<string>> Arch_outputMethodStrPL;  // string parameter for outputMethod;
+  static std::shared_ptr<ParameterLink<bool>>
+      Arch_writeMaxFilePL; // if true, Max file will be created
+  static std::shared_ptr<ParameterLink<bool>>
+      Arch_writePopFilePL; // if true, pop file will be created
+  static std::shared_ptr<ParameterLink<std::string>>
+      Arch_DefaultPopFileColumnNamesPL; // data to be saved into average file
+                                        // (must be values that can generate an
+                                        // average)
 
-	static shared_ptr<ParameterLink<bool>> Arch_writeMaxFilePL;  // if true, Max file will be created
-	static shared_ptr<ParameterLink<bool>> Arch_writePopFilePL;  // if true, pop file will be created
-	static shared_ptr<ParameterLink<string>> Arch_DefaultPopFileColumnNamesPL;  // data to be saved into average file (must be values that can generate an average)
+  static std::shared_ptr<ParameterLink<std::string>>
+      Arch_realtimeSequencePL; // how often to write out data
+  static std::shared_ptr<ParameterLink<std::string>>
+      SS_Arch_dataSequencePL; // how often to save data
+  static std::shared_ptr<ParameterLink<std::string>>
+      SS_Arch_organismSequencePL; // how often to save genomes
 
-	static shared_ptr<ParameterLink<string>> Arch_realtimeSequencePL;  // how often to write out data
-	static shared_ptr<ParameterLink<string>> SS_Arch_dataSequencePL;  // how often to save data
-	static shared_ptr<ParameterLink<string>> SS_Arch_organismSequencePL;  // how often to save genomes
+  static std::shared_ptr<ParameterLink<std::string>>
+      Arch_FilePrefixPL; // name of the Data file
+  static std::shared_ptr<ParameterLink<bool>>
+      SS_Arch_writeDataFilesPL; // if true, write data file
+  static std::shared_ptr<ParameterLink<bool>>
+      SS_Arch_writeOrganismsFilesPL; // if true, write genome file
 
-	static shared_ptr<ParameterLink<string>> Arch_FilePrefixPL;  // name of the Data file
-	static shared_ptr<ParameterLink<bool>> SS_Arch_writeDataFilesPL;  // if true, write data file
-	static shared_ptr<ParameterLink<bool>> SS_Arch_writeOrganismsFilesPL;  // if true, write genome file
+  bool writeMaxFile; // if true, Max file will be created
+  bool writePopFile; // if true, pop file will be created
+  std::string
+      MaxFileName; // name of the Max file (all stats for best brain when
+                   // file is writtne to)
+  std::string
+      PopFileName; // name of the Population file (ave and var for population
+                   // at each timepoint)
+  std::string PopFileColumnNames; // data to be saved into average file (must be
+                                  // values that can generate an average)
+  std::shared_ptr<Abstract_MTree>
+      maxFormula; // what value will be used to determine
+                  // which organism to write to max file
 
+  std::vector<int> realtimeSequence; // how often to write out data
+  int realtimeSequenceIndex;
 
+  std::vector<int> realtimeDataSequence;
+  std::vector<int> realtimeOrganismSequence;
+  int realtimeDataSeqIndex;
+  int realtimeOrganismSeqIndex;
 
+  std::string DataFilePrefix;     // name of the Data file
+  std::string OrganismFilePrefix; // name of the Genome file (genomes on LOD)
+  bool writeSnapshotDataFiles;    // if true, write data file
+  bool writeSnapshotGenomeFiles;  // if true, write genome file
 
-	bool writeMaxFile;  // if true, Max file will be created
-	bool writePopFile;  // if true, pop file will be created
-	string MaxFileName;  // name of the Max file (all stats for best brain when file is writtne to)
-	string PopFileName;  // name of the Population file (ave and var for population at each timepoint)
-	string PopFileColumnNames;  // data to be saved into average file (must be values that can generate an average)
-	shared_ptr<Abstract_MTree> maxFormula;  // what value will be used to determine which organism to write to max file
+  bool saveNewOrgs = false;
 
+  std::string groupPrefix;
 
-	vector<int> realtimeSequence;  // how often to write out data
-	int realtimeSequenceIndex;
+  std::map<std::string, std::vector<std::string>>
+      files; // list of files (NAME,LIST OF COLUMNS)
+  std::vector<std::string>
+      DefaultPopFileColumns; // what columns will be written into the PopFile
 
-	vector<int> realtimeDataSequence;
-	vector<int> realtimeOrganismSequence;
-	int realtimeDataSeqIndex;
-	int realtimeOrganismSeqIndex;
+  bool finished; // if finished, then as far as the archivist is concerned, we
+                 // can stop the run.
 
+  const std::shared_ptr<ParametersTable> PT;
 
-	string DataFilePrefix;  // name of the Data file
-	string OrganismFilePrefix;  // name of the Genome file (genomes on LOD)
-	bool writeSnapshotDataFiles;  // if true, write data file
-	bool writeSnapshotGenomeFiles;  // if true, write genome file
+  DefaultArchivist(std::shared_ptr<ParametersTable> _PT = nullptr,
+                   std::string _groupPrefix = "");
+  DefaultArchivist(std::vector<std::string> popFileColumns,
+                   std::shared_ptr<Abstract_MTree> _maxFormula = nullptr,
+                   std::shared_ptr<ParametersTable> _PT = nullptr,
+                   std::string _groupPrefix = "");
+  virtual ~DefaultArchivist() = default;
 
-	bool saveNewOrgs = false;
+  // save Max and average file data
+  void writeRealTimeFiles(std::vector<std::shared_ptr<Organism>> &population);
 
-	string groupPrefix;
+  void saveSnapshotData(std::vector<std::shared_ptr<Organism>> population);
 
-	map<string, vector<string>> files;  // list of files (NAME,LIST OF COLUMNS)
-	vector<string> DefaultPopFileColumns;  // what columns will be written into the PopFile
+  // void saveSnapshotGenomes(vector<shared_ptr<Organism>> population);
+  void saveSnapshotOrganisms(std::vector<std::shared_ptr<Organism>> population);
 
-	bool finished;  // if finished, then as far as the archivist is concerned, we can stop the run.
+  // save data and manage in memory data
+  // return true if next save will be > updates + terminate after
+  virtual bool archive(std::vector<std::shared_ptr<Organism>> population,
+                       int flush = 0);
 
-	const shared_ptr<ParametersTable> PT;
+  // virtual void processAllLists(OldDataMap &dm);
 
-	DefaultArchivist(shared_ptr<ParametersTable> _PT = nullptr, string _groupPrefix = "");
-	DefaultArchivist(vector<string> popFileColumns, shared_ptr<Abstract_MTree> _maxFormula = nullptr, shared_ptr<ParametersTable> _PT = nullptr, string _groupPrefix = "");
-	virtual ~DefaultArchivist() = default;
+  virtual bool isDataUpdate(int checkUpdate = -1);
+  virtual bool isOrganismUpdate(int checkUpdate = -1);
 
-	//save Max and average file data
-	void writeRealTimeFiles(vector<shared_ptr<Organism>> &population);
-
-	void saveSnapshotData(vector<shared_ptr<Organism>> population);
-
-	//void saveSnapshotGenomes(vector<shared_ptr<Organism>> population);
-	void saveSnapshotOrganisms(vector<shared_ptr<Organism>> population);
-
-	// save data and manage in memory data
-	// return true if next save will be > updates + terminate after
-	virtual bool archive(vector<shared_ptr<Organism>> population, int flush = 0);
-
-	//virtual void processAllLists(OldDataMap &dm);
-
-	virtual bool isDataUpdate(int checkUpdate = -1);
-	virtual bool isOrganismUpdate(int checkUpdate = -1);
-
-	map<string, int> uniqueColumnNameToOutputBehaviors;
-
+  std::map<std::string, int> uniqueColumnNameToOutputBehaviors;
 };

--- a/Brain/AbstractBrain.cpp
+++ b/Brain/AbstractBrain.cpp
@@ -11,8 +11,17 @@
 #include "AbstractBrain.h"
 
 ////// BRAIN-brainType is actually set by Modules.h //////
-shared_ptr<ParameterLink<string>> AbstractBrain::brainTypeStrPL = Parameters::register_parameter("BRAIN-brainType", (string) "This_string_is_set_by_modules.h", "This_string_is_set_by_modules.h");  // string parameter for outputMethod;
+std::shared_ptr<ParameterLink<std::string>> AbstractBrain::brainTypeStrPL =
+    Parameters::register_parameter(
+        "BRAIN-brainType", (std::string) "This_string_is_set_by_modules.h",
+        "This_string_is_set_by_modules.h"); // string parameter for
+                                            // outputMethod;
 ////// BRAIN-brainType is actually set by Modules.h //////
 
-																																																					  //shared_ptr<ParameterLink<int>> AbstractBrain::hiddenNodesPL = Parameters::register_parameter("BRAIN-hiddenNodes", 8, "number of hidden nodes, if brain type supports hiden nodes");  // string parameter for outputMethod;
-//shared_ptr<ParameterLink<bool>> AbstractBrain::serialProcessingPL = Parameters::register_parameter("BRAIN-serialProcessing", false, "outputs from units will write to nodes, not nodesNext");
+// shared_ptr<ParameterLink<int>> AbstractBrain::hiddenNodesPL =
+// Parameters::register_parameter("BRAIN-hiddenNodes", 8, "number of hidden
+// nodes, if brain type supports hiden nodes");  // string parameter for
+// outputMethod;
+// shared_ptr<ParameterLink<bool>> AbstractBrain::serialProcessingPL =
+// Parameters::register_parameter("BRAIN-serialProcessing", false, "outputs from
+// units will write to nodes, not nodesNext");

--- a/Brain/AbstractBrain.h
+++ b/Brain/AbstractBrain.h
@@ -22,176 +22,212 @@
 #include "../Utilities/Parameters.h"
 #include "../Global.h"
 
-using namespace std;
 class AbstractBrain {
 public:
-	static shared_ptr<ParameterLink<string>> brainTypeStrPL;
+  static std::shared_ptr<ParameterLink<std::string>> brainTypeStrPL;
 
-	const shared_ptr<ParametersTable> PT;
+  const std::shared_ptr<ParametersTable> PT;
 
-	vector<string> popFileColumns;
+  std::vector<std::string> popFileColumns;
 
-	bool recordActivity;
-	string recordActivityFileName;
+  bool recordActivity;
+  std::string recordActivityFileName;
 
-	int nrInputValues;
-	int nrOutputValues;
-	vector<double> inputValues;
-	vector<double> outputValues;
+  int nrInputValues;
+  int nrOutputValues;
+  std::vector<double> inputValues;
+  std::vector<double> outputValues;
 
-	AbstractBrain() = delete;
+  AbstractBrain() = delete;
 
-	AbstractBrain(int ins, int outs, shared_ptr<ParametersTable> _PT) : PT(_PT) {
-		nrInputValues = ins;
-		nrOutputValues = outs;
-		recordActivity = false;
+  AbstractBrain(int ins, int outs, std::shared_ptr<ParametersTable> _PT)
+      : PT(_PT) {
+    nrInputValues = ins;
+    nrOutputValues = outs;
+    recordActivity = false;
 
-		inputValues.resize(nrInputValues);
-		outputValues.resize(nrOutputValues);
+    inputValues.resize(nrInputValues);
+    outputValues.resize(nrOutputValues);
+  }
 
-	}
+  virtual ~AbstractBrain() = default;
 
-	virtual ~AbstractBrain() = default;
+  virtual void update() = 0;
 
-	virtual void update() = 0;
+  virtual std::string
+  description() = 0; // returns a desription of this brain in it's current state
+  virtual DataMap getStats(std::string &prefix) = 0; // returns a vector of string
+                                                // pairs of any stats that can
+                                                // then be used for data
+                                                // tracking (etc.)
+  virtual std::string getType() {
+    std::cout << "ERROR! In AbstractBrain::getType()...\n This genome needs a "
+            "getType function...\n  exiting.";
+    exit(1);
+    return "Undefined";
+  }
 
-	virtual string description() = 0;  // returns a desription of this brain in it's current state
-	virtual DataMap getStats(string& prefix) = 0;  // returns a vector of string pairs of any stats that can then be used for data tracking (etc.)
-	virtual string getType() {
-		cout << "ERROR! In AbstractBrain::getType()...\n This genome needs a getType function...\n  exiting.";
-		exit(1);
-		return "Undefined";
-	}
+  // convert a brain into data map with data that can be saved to file
+  virtual DataMap serialize(std::string &name) {
+    // cout << "ERROR! In AbstractBrain::serialize(). This method has not been
+    // written for the type of brain use are using.\n  Exiting.";
+    // exit(1);
+    // return an empty data map - this is the case for a brain built from genome
+    // where no data needs to be saved
+    DataMap tempDataMap;
+    return tempDataMap;
+  }
 
-	// convert a brain into data map with data that can be saved to file
-	virtual DataMap serialize(string& name) {
-		//cout << "ERROR! In AbstractBrain::serialize(). This method has not been written for the type of brain use are using.\n  Exiting.";
-		//exit(1);
-		// return an empty data map - this is the case for a brain built from genome where no data needs to be saved
-		DataMap tempDataMap;
-		return tempDataMap;
-	}
+  // given an unordered_map<string, string> and PT, load data into this brain
+  virtual void deserialize(std::shared_ptr<ParametersTable> PT,
+                           std::unordered_map<std::string, std::string> &orgData,
+                           std::string &name) {
+    // cout << "ERROR! In AbstractBrain::deserialize(). This method has not been
+    // written for the type of brain use are using.\n  Exiting.";
+    // exit(1);
+    // do nothing... if this brain is built from genome, then nothing needs to
+    // be done.
+  }
 
-	// given an unordered_map<string, string> and PT, load data into this brain
-	virtual void deserialize(shared_ptr<ParametersTable> PT, unordered_map<string, string>& orgData, string& name) {
-		//cout << "ERROR! In AbstractBrain::deserialize(). This method has not been written for the type of brain use are using.\n  Exiting.";
-		//exit(1);
-		// do nothing... if this brain is built from genome, then nothing needs to be done.
-	}
+  virtual void initializeGenomes(
+      std::unordered_map<std::string, std::shared_ptr<AbstractGenome>> &_genomes){
+      // do nothing by default... if this is a direct encoded brain, then no
+      // action is needed.
+      // should this be a madiatory function?
+  };
 
+  // Make a brain like the brain that called this function, using genomes and
+  // initalizing other elements.
+  virtual std::shared_ptr<AbstractBrain>
+  makeBrain(std::unordered_map<std::string, std::shared_ptr<AbstractGenome>> &_genomes) {
+    std::cout << "WARRNING! you have called AbstractBrain::encodeBarin - This "
+            "function must be defined from each brain type."
+         << std::endl
+         << "Exiting." << std::endl;
+    exit(1);
+    return makeCopy();
+  }
 
-	virtual void initializeGenomes(unordered_map<string, shared_ptr<AbstractGenome>>& _genomes) {
-		// do nothing by default... if this is a direct encoded brain, then no action is needed.
-		// should this be a madiatory function?
-	};
+  // Make a brain like the brain that called this function, using genomes and
+  // inheriting other elements from parent.
+  // in the default case, we assume geneticly encoded brains, so this just calls
+  // the no parent version (i.e. build from genomes)
+  virtual std::shared_ptr<AbstractBrain>
+  makeBrainFrom(std::shared_ptr<AbstractBrain> parent,
+                std::unordered_map<std::string, std::shared_ptr<AbstractGenome>> &_genomes) {
+    return makeBrain(_genomes);
+  }
 
-	// Make a brain like the brain that called this function, using genomes and initalizing other elements.
-	virtual shared_ptr<AbstractBrain> makeBrain(unordered_map<string,shared_ptr<AbstractGenome>>& _genomes) {
-		cout << "WARRNING! you have called AbstractBrain::encodeBarin - This function must be defined from each brain type." << endl << "Exiting." << endl;
-		exit(1);
-		return makeCopy();
-	 }
+  // Make a brain like the brain that called this function, using genomes and
+  // inheriting other elements from parents.
+  // in the default case, we assume geneticly encoded brains, so this just calls
+  // the no parent version (i.e. build from genomes)
+  virtual std::shared_ptr<AbstractBrain> makeBrainFromMany(
+      std::vector<std::shared_ptr<AbstractBrain>> parents,
+      std::unordered_map<std::string, std::shared_ptr<AbstractGenome>> &_genomes) {
+    return makeBrain(_genomes);
+  }
 
-	// Make a brain like the brain that called this function, using genomes and inheriting other elements from parent.
-	// in the default case, we assume geneticly encoded brains, so this just calls the no parent version (i.e. build from genomes)
-	virtual shared_ptr<AbstractBrain> makeBrainFrom(shared_ptr<AbstractBrain> parent, unordered_map<string, shared_ptr<AbstractGenome>>& _genomes){
-		return makeBrain(_genomes);
-	}
+  // apply direct mutations to this brain
+  virtual void mutate() {
+    // do nothing by default... if this is not a direct encoded brain, then no
+    // action is needed.
+    // should this be a madiatory function?
+  }
 
-	// Make a brain like the brain that called this function, using genomes and inheriting other elements from parents.
-	// in the default case, we assume geneticly encoded brains, so this just calls the no parent version (i.e. build from genomes)
-	virtual shared_ptr<AbstractBrain> makeBrainFromMany(vector<shared_ptr<AbstractBrain>> parents, unordered_map<string, shared_ptr<AbstractGenome>>& _genomes){
-		return makeBrain(_genomes);
-	}
+  virtual void inline resetBrain() {
+    resetInputs();
+    resetOutputs();
+  }
 
-	// apply direct mutations to this brain
-	virtual void mutate() {
-		// do nothing by default... if this is not a direct encoded brain, then no action is needed.
-		// should this be a madiatory function?
-	}
+  virtual void inline setRecordActivity(bool _recordActivity) {
+    recordActivity = _recordActivity;
+  }
 
-	virtual void inline resetBrain() {
-		resetInputs();
-		resetOutputs();
-	}
+  virtual void inline setRecordFileName(std::string _recordActivityFileName) {
+    recordActivityFileName = _recordActivityFileName;
+  }
 
-	virtual void inline setRecordActivity(bool _recordActivity) {
-		recordActivity = _recordActivity;
-	}
+  virtual void inline resetOutputs() {
+    for (int i = 0; i < nrOutputValues; i++) {
+      outputValues[i] = 0.0;
+    }
+  }
 
-	virtual void inline setRecordFileName(string _recordActivityFileName) {
-		recordActivityFileName = _recordActivityFileName;
-	}
+  virtual void inline resetInputs() {
+    for (int i = 0; i < nrInputValues; i++) {
+      inputValues[i] = 0.0;
+    }
+  }
 
-	virtual void inline resetOutputs() {
-		for (int i = 0; i < nrOutputValues; i++) {
-			outputValues[i] = 0.0;
-		}
-	}
+  inline virtual void setInput(const int &inputAddress, const double &value) {
+    if (inputAddress < nrInputValues) {
+      inputValues[inputAddress] = value;
+    } else {
+      std::cout << "in Brain::setInput() : Writing to invalid input ("
+           << inputAddress << ") - this brain needs more inputs!\nExiting"
+           << std::endl;
+      exit(1);
+    }
+  }
 
-	virtual void inline resetInputs() {
-		for (int i = 0; i < nrInputValues; i++) {
-			inputValues[i] = 0.0;
-		}
-	}
+  inline virtual double readInput(const int &inputAddress) {
+    if (inputAddress < nrInputValues) {
+      return inputValues[inputAddress];
+    } else {
+      std::cout << "in Brain::readInput() : Reading from invalid input ("
+           << inputAddress << ") - this brain needs more inputs!\nExiting"
+           << std::endl;
+      exit(1);
+    }
+  }
 
-	inline virtual void setInput(const int& inputAddress, const double& value) {
-		if (inputAddress < nrInputValues) {
-			inputValues[inputAddress] = value;
-		} else {
-			cout << "in Brain::setInput() : Writing to invalid input (" << inputAddress << ") - this brain needs more inputs!\nExiting" << endl;
-			exit(1);
-		}
-	}
+  inline virtual void setOutput(const int &outputAddress, const double &value) {
+    if (outputAddress < nrOutputValues) {
+      outputValues[outputAddress] = value;
+    } else {
+      std::cout << "in Brain::setOutput() : Writing to invalid output ("
+           << outputAddress << ") - this brain needs more outputs!\nExiting"
+           << std::endl;
+      exit(1);
+    }
+  }
 
-	inline virtual double readInput(const int& inputAddress) {
-		if (inputAddress < nrInputValues) {
-			return inputValues[inputAddress];
-		} else {
-			cout << "in Brain::readInput() : Reading from invalid input (" << inputAddress << ") - this brain needs more inputs!\nExiting" << endl;
-			exit(1);
-		}
-	}
+  inline virtual double readOutput(const int &outputAddress) {
+    if (outputAddress < nrOutputValues) {
+      return outputValues[outputAddress];
+    } else {
+      std::cout << "in Brain::readOutput() : Reading from invalid output ("
+           << outputAddress << ") - this brain needs more outputs!\nExiting"
+           << std::endl;
+      exit(1);
+    }
+  }
 
-	inline virtual void setOutput(const int& outputAddress, const double& value) {
-		if (outputAddress < nrOutputValues) {
-			outputValues[outputAddress] = value;
-		} else {
-			cout << "in Brain::setOutput() : Writing to invalid output (" << outputAddress << ") - this brain needs more outputs!\nExiting" << endl;
-			exit(1);
-		}
-	}
+  //	// converts the value of each value in nodes[] to bit and converts the
+  //bits to an int
+  //	// useful to generate values for lookups, useful for caching
+  //	int allNodesToBitToInt() {
+  //		int result = 0;
+  //		for (int i = 0; i < nrOfBrainNodes; i++)
+  //			result = (result) + Bit(nodes[i]);
+  //		return result;
+  //
+  //	}
 
-	inline virtual double readOutput(const int& outputAddress) {
-		if (outputAddress < nrOutputValues) {
-			return outputValues[outputAddress];
-		} else {
-			cout << "in Brain::readOutput() : Reading from invalid output (" << outputAddress << ") - this brain needs more outputs!\nExiting" << endl;
-			exit(1);
-		}
-	}
+  virtual std::shared_ptr<AbstractBrain>
+  makeCopy(std::shared_ptr<ParametersTable> _PT = nullptr) {
+    std::cout << "ERROR IN AbstractBrain::makeCopy() - You are using the abstract "
+            "copy constructor for brains. You must define your own"
+         << std::endl;
+    exit(1);
+  }
 
-//	// converts the value of each value in nodes[] to bit and converts the bits to an int
-//	// useful to generate values for lookups, useful for caching
-//	int allNodesToBitToInt() {
-//		int result = 0;
-//		for (int i = 0; i < nrOfBrainNodes; i++)
-//			result = (result) + Bit(nodes[i]);
-//		return result;
-//
-//	}
-
-	virtual shared_ptr<AbstractBrain> makeCopy(shared_ptr<ParametersTable> _PT = nullptr) {
-		cout << "ERROR IN AbstractBrain::makeCopy() - You are using the abstract copy constructor for brains. You must define your own" << endl;
-		exit(1);
-	}
-
-	virtual unordered_set<string> requiredGenomes() {
-		return { "root::" };
-		// "root" = use empty name space
-		// "GROUP::" = use group name space
-		// "blah" = use "blah namespace at root level
-		// "Group::blah" = use "blah" name space inside of group name space
-	}
-
+  virtual std::unordered_set<std::string> requiredGenomes() {
+    return {"root::"};
+    // "root" = use empty name space
+    // "GROUP::" = use group name space
+    // "blah" = use "blah namespace at root level
+    // "Group::blah" = use "blah" name space inside of group name space
+  }
 };

--- a/Genome/AbstractGenome.cpp
+++ b/Genome/AbstractGenome.cpp
@@ -12,10 +12,20 @@
 
 
 ////// GENOME-genomeType is actually set by Modules.h //////
-shared_ptr<ParameterLink<string>> AbstractGenome::genomeTypeStrPL = Parameters::register_parameter("GENOME-genomeType", (string) "This_string_is_set_by_modules.h", "This_string_is_set_by_modules.h");  // string parameter for outputMethod;
+std::shared_ptr<ParameterLink<std::string>> AbstractGenome::genomeTypeStrPL =
+    Parameters::register_parameter(
+        "GENOME-genomeType", (std::string) "This_string_is_set_by_modules.h",
+        "This_string_is_set_by_modules.h"); // string parameter for
+                                            // outputMethod;
 ////// GENOME-genomeType is actually set by Modules.h //////
-shared_ptr<ParameterLink<double>> AbstractGenome::alphabetSizePL = Parameters::register_parameter("GENOME-alphabetSize", 256.0, "alphabet size for genome");  // string parameter for outputMethod;
-shared_ptr<ParameterLink<string>> AbstractGenome::genomeSitesTypePL = Parameters::register_parameter("GENOME-sitesType", (string) "char", "type for sites in genome [char, int, double, bool]");  // string parameter for outputMethod;
-
-
+std::shared_ptr<ParameterLink<double>> AbstractGenome::alphabetSizePL =
+    Parameters::register_parameter(
+        "GENOME-alphabetSize", 256.0,
+        "alphabet size for genome"); // string parameter for outputMethod;
+std::shared_ptr<ParameterLink<std::string>> AbstractGenome::genomeSitesTypePL =
+    Parameters::register_parameter(
+        "GENOME-sitesType", (std::string) "char",
+        "type for sites in genome [char, int, double, bool]"); // string
+                                                               // parameter for
+                                                               // outputMethod;
 

--- a/Genome/AbstractGenome.h
+++ b/Genome/AbstractGenome.h
@@ -23,198 +23,220 @@
 #include "../Utilities/Parameters.h"
 #include "../Utilities/Random.h"
 
-using namespace std;
-
 class AbstractGenome {
 
 public:
-	static shared_ptr<ParameterLink<string>> genomeTypeStrPL;
-	static shared_ptr<ParameterLink<double>> alphabetSizePL;
-	static shared_ptr<ParameterLink<string>> genomeSitesTypePL;
+  static std::shared_ptr<ParameterLink<std::string>> genomeTypeStrPL;
+  static std::shared_ptr<ParameterLink<double>> alphabetSizePL;
+  static std::shared_ptr<ParameterLink<std::string>> genomeSitesTypePL;
 
-	const shared_ptr<ParametersTable> PT;
+  const std::shared_ptr<ParametersTable> PT;
 
-	// Handlers are how you access Genomes for reading and writting.
-	// to get a handle for a genome call that that genomes newHandler() method
-	class Handler {
-	public:
-		//shared_ptr<AbstractGenome> genome;
-		bool readDirection;  // true = forward, false = backwards
-		bool EOG;  // end of genome
-		bool EOC;  // end of chromosome - in this context chromosome is a subsection of the genome
-				   // which after having passed we may want to perform some different behavior
+  // Handlers are how you access Genomes for reading and writting.
+  // to get a handle for a genome call that that genomes newHandler() method
+  class Handler {
+  public:
+    // shared_ptr<AbstractGenome> genome;
+    bool readDirection; // true = forward, false = backwards
+    bool EOG;           // end of genome
+    bool EOC; // end of chromosome - in this context chromosome is a subsection
+              // of the genome
+    // which after having passed we may want to perform some different behavior
 
-		Handler() {
-			readDirection = true;
-			EOG = false;
-			EOC = false;
-		}
+    Handler() {
+      readDirection = true;
+      EOG = false;
+      EOC = false;
+    }
 
-		Handler(shared_ptr<AbstractGenome> _genome, bool _readDirection = true) {
-			readDirection = _readDirection;
-			EOG = false;
-			EOC = false;
-		}
+    Handler(std::shared_ptr<AbstractGenome> _genome,
+            bool _readDirection = true) {
+      readDirection = _readDirection;
+      EOG = false;
+      EOC = false;
+    }
 
-		virtual void resetEOG() {
-			EOG = false;
-			EOC = false;
-		}
+    virtual void resetEOG() {
+      EOG = false;
+      EOC = false;
+    }
 
-		virtual void resetEOC() {
-			EOC = false;
-		}
+    virtual void resetEOC() { EOC = false; }
 
-		virtual void setReadDirection(bool _readDirection) {
-			readDirection = _readDirection;
-		}
+    virtual void setReadDirection(bool _readDirection) {
+      readDirection = _readDirection;
+    }
 
-		virtual void toggleReadDirection() {
-			readDirection = !readDirection;
-		}
+    virtual void toggleReadDirection() { readDirection = !readDirection; }
 
-		virtual void resetHandler() = 0;
-		virtual void resetHandlerOnChromosome() = 0;
+    virtual void resetHandler() = 0;
+    virtual void resetHandlerOnChromosome() = 0;
 
-		virtual ~Handler() {
-		}
+    virtual ~Handler() {}
 
-		//// convert genome sites at location index into a value in range [min,max] and advance index to the next unused site
-		//// any sites used will be assigned code in codingRegions
-		//// no undefined action, this function must be defined
-		virtual int readInt(int valueMin, int valueMax, int code = -1, int CodingRegionIndex = 0) = 0;
+    //// convert genome sites at location index into a value in range [min,max]
+    ///and advance index to the next unused site
+    //// any sites used will be assigned code in codingRegions
+    //// no undefined action, this function must be defined
+    virtual int readInt(int valueMin, int valueMax, int code = -1,
+                        int CodingRegionIndex = 0) = 0;
 
-		virtual double readDouble(double valueMin, double valueMax, int code = -1, int CodingRegionIndex = 0) {
-			cout << "ERROR: readDouble(double valueMin, double valueMax, int code = -1, int CodingRegionIndex = 0) in AbstractGenome::Handler was called!\n This has not been implemented yet the chromosome class you are using!\n";
-			exit(1);
-			return 0.0;
-		}
+    virtual double readDouble(double valueMin, double valueMax, int code = -1,
+                              int CodingRegionIndex = 0) {
+      std::cout << "ERROR: readDouble(double valueMin, double valueMax, int code = "
+              "-1, int CodingRegionIndex = 0) in AbstractGenome::Handler was "
+              "called!\n This has not been implemented yet the chromosome "
+              "class you are using!\n";
+      exit(1);
+      return 0.0;
+    }
 
-		virtual void writeInt(int value, int valueMin, int valueMax) = 0;
-		virtual void writeDouble(double value, double valueMin, double valueMax) {
-			cout << "ERROR: writeDouble(double value, double valueMin, double valueMax) in AbstractGenome::Handler was called!\n This has not been implemented yet the chromosome class you are using!\n";
-			exit(1);
-		}
-		virtual vector<vector<int>> readTable(pair<int, int> tableSize, pair<int, int> tableMaxSize, pair<int, int> valueRange, int code = -1, int CodingRegionIndex = 0)=0;
-		virtual void advanceIndex(int distance = 1) = 0;
+    virtual void writeInt(int value, int valueMin, int valueMax) = 0;
+    virtual void writeDouble(double value, double valueMin, double valueMax) {
+      std::cout << "ERROR: writeDouble(double value, double valueMin, double "
+              "valueMax) in AbstractGenome::Handler was called!\n This has not "
+              "been implemented yet the chromosome class you are using!\n";
+      exit(1);
+    }
+    virtual std::vector<std::vector<int>> readTable(std::pair<int, int> tableSize,
+                                          std::pair<int, int> tableMaxSize,
+                                          std::pair<int, int> valueRange,
+                                          int code = -1,
+                                          int CodingRegionIndex = 0) = 0;
+    virtual void advanceIndex(int distance = 1) = 0;
 
-		virtual shared_ptr<AbstractGenome::Handler> makeCopy() {
-			cout << "  ERROR :: in AbstractGenome::Handler::makeCopy() - You are using the abstract version of this function. This method has not been defined for the class you are using.\n  Exiting." << endl;
-			exit(1);
-		}
+    virtual std::shared_ptr<AbstractGenome::Handler> makeCopy() {
+      std::cout << "  ERROR :: in AbstractGenome::Handler::makeCopy() - You are "
+              "using the abstract version of this function. This method has "
+              "not been defined for the class you are using.\n  Exiting."
+           << std::endl;
+      exit(1);
+    }
 
-		virtual void copyTo(shared_ptr<Handler> to) = 0;
+    virtual void copyTo(std::shared_ptr<Handler> to) = 0;
 
-		virtual bool atEOG() {
-			return false;
-		}
+    virtual bool atEOG() { return false; }
 
-		virtual bool atEOC() {
-			return false;
-		}
+    virtual bool atEOC() { return false; }
 
-		virtual void printIndex() = 0;
+    virtual void printIndex() = 0;
 
-		virtual bool inTelomere(int length) {
-			return false;
-		}
+    virtual bool inTelomere(int length) { return false; }
 
-		virtual void randomize() = 0;
-	};
+    virtual void randomize() = 0;
+  };
 
-	DataMap dataMap;
-	vector<string> genomeFileColumns;  // = {"ID","alphabetSize","chromosomeCount","chromosomeLength","sitesCount","genomeAncestors","sites"};
-	vector<string> popFileColumns;  // = {"genomeLength"};
+  DataMap dataMap;
+  std::vector<std::string>
+      genomeFileColumns;         // =
+                                 // {"ID","alphabetSize","chromosomeCount","chromosomeLength","sitesCount","genomeAncestors","sites"};
+  std::vector<std::string> popFileColumns; // = {"genomeLength"};
 
-	AbstractGenome() = delete;
-	AbstractGenome(shared_ptr<ParametersTable> _PT) : PT(_PT) {}
+  AbstractGenome() = delete;
+  AbstractGenome(std::shared_ptr<ParametersTable> _PT) : PT(_PT) {}
 
-	virtual ~AbstractGenome() = default;
-	//virtual shared_ptr<AbstractGenome::Handler> newHandler(shared_ptr<AbstractGenome> _genome, bool _readDirection = true) override {
+  virtual ~AbstractGenome() = default;
+  // virtual shared_ptr<AbstractGenome::Handler>
+  // newHandler(shared_ptr<AbstractGenome> _genome, bool _readDirection = true)
+  // override {
 
-	virtual shared_ptr<AbstractGenome> makeCopy(shared_ptr<ParametersTable> _PT) {
-		cout << "ERROR IN AbstractGenome::makeCopy() - You are using the abstract copy constructor for genomes. You must define your own" << endl;
-		exit(1);
-	}
+  virtual std::shared_ptr<AbstractGenome> makeCopy(std::shared_ptr<ParametersTable> _PT) {
+    std::cout << "ERROR IN AbstractGenome::makeCopy() - You are using the abstract "
+            "copy constructor for genomes. You must define your own"
+         << std::endl;
+    exit(1);
+  }
 
-	virtual shared_ptr<AbstractGenome> makeLike() = 0;
+  virtual std::shared_ptr<AbstractGenome> makeLike() = 0;
 
-	virtual shared_ptr<AbstractGenome::Handler> newHandler(shared_ptr<AbstractGenome> _genome, bool _readDirection = true) = 0;
-	virtual double getAlphabetSize() = 0;
+  virtual std::shared_ptr<AbstractGenome::Handler>
+  newHandler(std::shared_ptr<AbstractGenome> _genome,
+             bool _readDirection = true) = 0;
+  virtual double getAlphabetSize() = 0;
 
-	virtual void copyFrom(shared_ptr<AbstractGenome> from) = 0;
+  virtual void copyFrom(std::shared_ptr<AbstractGenome> from) = 0;
 
-	virtual void fillRandom() = 0;
+  virtual void fillRandom() = 0;
 
-	//// gets data about genome which can be added to a data map
-	//// data is in pairs of strings (key, value)
-	//// the undefined action is to return an empty vector
-	virtual DataMap getStats(string& name) {
-		DataMap data;
-		cout << "Warning! In AbstractGenome::getStats()...\n";
-		return data;
-	}
+  //// gets data about genome which can be added to a data map
+  //// data is in pairs of strings (key, value)
+  //// the undefined action is to return an empty vector
+  virtual DataMap getStats(std::string &name) {
+    DataMap data;
+    std::cout << "Warning! In AbstractGenome::getStats()...\n";
+    return data;
+  }
 
-	// convert a genome into data map with data that can be saved to file
-	virtual DataMap serialize(string& name) {
-		cout << "ERROR! In AbstractGenome::serialize(). This method has not been written for the type of genome use are using.\n  Exiting.";
-		exit(1);
-		DataMap tempDataMap;
-		return tempDataMap;
-	}
+  // convert a genome into data map with data that can be saved to file
+  virtual DataMap serialize(std::string &name) {
+    std::cout << "ERROR! In AbstractGenome::serialize(). This method has not been "
+            "written for the type of genome use are using.\n  Exiting.";
+    exit(1);
+    DataMap tempDataMap;
+    return tempDataMap;
+  }
 
-	// given a an unordered_map<string, string> and PT, load data into this genome
-	virtual void deserialize (shared_ptr<ParametersTable> PT, unordered_map<string, string>& orgData, string& name) {
-		cout << "ERROR! In AbstractGenome::deserialize(). This method has not been written for the type of genome use are using.\n  Exiting.";
-		exit(1);
-	}
+  // given a an unordered_map<string, string> and PT, load data into this genome
+  virtual void deserialize(std::shared_ptr<ParametersTable> PT,
+                           std::unordered_map<std::string, std::string> &orgData,
+                           std::string &name) {
+    std::cout << "ERROR! In AbstractGenome::deserialize(). This method has not been "
+            "written for the type of genome use are using.\n  Exiting.";
+    exit(1);
+  }
 
-	virtual string genomeToStr() {
-		cout << "Warning! In AbstractGenome::genomeToStr()...\n";
-		return "";
-	}
+  virtual std::string genomeToStr() {
+    std::cout << "Warning! In AbstractGenome::genomeToStr()...\n";
+    return "";
+  }
 
-	virtual void printGenome() {
-		cout << "Warning! In AbstractGenome::printGenome()...\n";
-	}
+  virtual void printGenome() {
+    std::cout << "Warning! In AbstractGenome::printGenome()...\n";
+  }
 
-	virtual void loadGenomeFile(string fileName, vector<shared_ptr<AbstractGenome>> &genomes) {
-		cout << "loadGenomeFile() has not been defined for this type of genome!" << endl;
-		exit(1);
-	}
+  virtual void loadGenomeFile(std::string fileName,
+                              std::vector<std::shared_ptr<AbstractGenome>> &genomes) {
+    std::cout << "loadGenomeFile() has not been defined for this type of genome!"
+         << std::endl;
+    exit(1);
+  }
 
-	// loadGenome will load file "fileName" and return the first genome whos dataMap matches key,value
-	// if no genome matches, function returns nullptr
-	// if more then one genome matches, function return first match
-	virtual shared_ptr<AbstractGenome> loadGenome(string fileName, string key, string value) {
-		vector<shared_ptr<AbstractGenome>> genomes;
-		loadGenomeFile(fileName, genomes);
-		for (auto g : genomes) {
-			if (to_string(g->dataMap.getIntVector(key)[0]) == value) {
-				return g;
-			}
-		}
-		return nullptr;
-	}
+  // loadGenome will load file "fileName" and return the first genome whos
+  // dataMap matches key,value
+  // if no genome matches, function returns nullptr
+  // if more then one genome matches, function return first match
+  virtual std::shared_ptr<AbstractGenome> loadGenome(std::string fileName, std::string key,
+                                                std::string value) {
+    std::vector<std::shared_ptr<AbstractGenome>> genomes;
+    loadGenomeFile(fileName, genomes);
+    for (auto g : genomes) {
+      if (std::to_string(g->dataMap.getIntVector(key)[0]) == value) {
+        return g;
+      }
+    }
+    return nullptr;
+  }
 
-	virtual bool isEmpty() = 0;
+  virtual bool isEmpty() = 0;
 
-	virtual void mutate() = 0;
-	virtual shared_ptr<AbstractGenome> makeMutatedGenomeFrom(shared_ptr<AbstractGenome> parent) = 0;
-	virtual shared_ptr<AbstractGenome> makeMutatedGenomeFromMany(vector<shared_ptr<AbstractGenome>> parents) = 0;
+  virtual void mutate() = 0;
+  virtual std::shared_ptr<AbstractGenome>
+  makeMutatedGenomeFrom(std::shared_ptr<AbstractGenome> parent) = 0;
+  virtual std::shared_ptr<AbstractGenome>
+  makeMutatedGenomeFromMany(std::vector<std::shared_ptr<AbstractGenome>> parents) = 0;
 
-	virtual int countSites() {
-		cout << "Warning! In AbstractGenome::countSites()...\n";
-		return 0;
-	}
+  virtual int countSites() {
+    std::cout << "Warning! In AbstractGenome::countSites()...\n";
+    return 0;
+  }
 
-	virtual string getType() {
-		cout << "ERROR! In AbstractGenome::getType()...\n This genome needs a getType function...\n  exiting.";
-		exit(1);
-		return "Undefined";
-	}
+  virtual std::string getType() {
+    std::cout << "ERROR! In AbstractGenome::getType()...\n This genome needs a "
+            "getType function...\n  exiting.";
+    exit(1);
+    return "Undefined";
+  }
 
-	virtual void recordDataMap() = 0;
-
+  virtual void recordDataMap() = 0;
 };
 

--- a/Group/Group.cpp
+++ b/Group/Group.cpp
@@ -10,27 +10,22 @@
 
 #include "../Group/Group.h"
 
-Group::Group() {  // create an empty Group
+Group::Group() { // create an empty Group
 }
 
-Group::Group(vector<shared_ptr<Organism>> _population, shared_ptr<AbstractOptimizer> _optimizer, shared_ptr<DefaultArchivist> _archivist) {
-	population = _population;
-	optimizer = _optimizer;
-	archivist = _archivist;
+Group::Group(std::vector<std::shared_ptr<Organism>> _population,
+             std::shared_ptr<AbstractOptimizer> _optimizer,
+             std::shared_ptr<DefaultArchivist> _archivist) {
+  population = _population;
+  optimizer = _optimizer;
+  archivist = _archivist;
 }
 
-Group::~Group() {
-}
+Group::~Group() {}
 
-bool Group::archive(int flush) {
-	return archivist->archive(population, flush);
-}
+bool Group::archive(int flush) { return archivist->archive(population, flush); }
 
-void Group::optimize() {
-	optimizer->optimize(population);
-}
+void Group::optimize() { optimizer->optimize(population); }
 
-void Group::cleanup() {
-	optimizer->cleanup(population);
-}
+void Group::cleanup() { optimizer->cleanup(population); }
 

--- a/Group/Group.h
+++ b/Group/Group.h
@@ -15,21 +15,21 @@
 #include "../Optimizer/AbstractOptimizer.h"
 #include "../Organism/Organism.h"
 
-using namespace std;
-
 class Group {
- public:
-	vector<shared_ptr<Organism>> population;
-	shared_ptr<Organism> templateOrg;
-	shared_ptr<DefaultArchivist> archivist;
-	shared_ptr<AbstractOptimizer> optimizer;
+public:
+  std::vector<std::shared_ptr<Organism>> population;
+  std::shared_ptr<Organism> templateOrg;
+  std::shared_ptr<DefaultArchivist> archivist;
+  std::shared_ptr<AbstractOptimizer> optimizer;
 
-	Group();
-	Group(vector<shared_ptr<Organism>> _population, shared_ptr<AbstractOptimizer> _optimizer, shared_ptr<DefaultArchivist> _archivist);
-	~Group();
+  Group();
+  Group(std::vector<std::shared_ptr<Organism>> _population,
+        std::shared_ptr<AbstractOptimizer> _optimizer,
+        std::shared_ptr<DefaultArchivist> _archivist);
+  ~Group();
 
-	bool archive(int flush = 0);
-	void optimize();
-	void cleanup();
+  bool archive(int flush = 0);
+  void optimize();
+  void cleanup();
 };
 

--- a/Optimizer/AbstractOptimizer.cpp
+++ b/Optimizer/AbstractOptimizer.cpp
@@ -10,16 +10,20 @@
 
 #include "AbstractOptimizer.h"
 
+/*
 #include <algorithm>
 #include <math.h>
-#include <stdlib.h>     // for atoi
+#include <stdlib.h> // for atoi
 
 #include "../Utilities/Random.h"
-
-using namespace std;
+*/
 
 ////// OPTIMIZER-optimizer is actually set by Modules.h //////
-shared_ptr<ParameterLink<string>> AbstractOptimizer::Optimizer_MethodStrPL = Parameters::register_parameter("OPTIMIZER-optimizer", (string) "This_string_is_set_by_modules.h", "This_string_is_set_by_modules.h");  // string parameter for outputMethod;
+std::shared_ptr<ParameterLink<std::string>> AbstractOptimizer::Optimizer_MethodStrPL =
+    Parameters::register_parameter(
+        "OPTIMIZER-optimizer", (std::string) "This_string_is_set_by_modules.h",
+        "This_string_is_set_by_modules.h"); // string parameter for
+                                            // outputMethod;
 ////// OPTIMIZER-optimizer is actually set by Modules.h //////
 
 /*
@@ -27,14 +31,17 @@ shared_ptr<ParameterLink<string>> AbstractOptimizer::Optimizer_MethodStrPL = Par
  * place holder function, copies population to make new population
  * no selection and no mutation
  */
-//void BaseOptimizer::makeNextGeneration(vector<shared_ptr<Organism>> &population) {
+// void BaseOptimizer::makeNextGeneration(vector<shared_ptr<Organism>>
+// &population) {
 //	vector<shared_ptr<Organism>> nextPopulation;
 //	for (size_t i = 0; i < population.size(); i++) {
-//		shared_ptr<Organism> newOrg = make_shared<Organism>(population[i], population[i]->genome);
+//		shared_ptr<Organism> newOrg = make_shared<Organism>(population[i],
+//population[i]->genome);
 //		nextPopulation.push_back(newOrg);
 //	}
 //	for (size_t i = 0; i < population.size(); i++) {
-//		population[i]->kill();  // set org.alive = 0 and delete the organism if it has no offspring
+//		population[i]->kill();  // set org.alive = 0 and delete the
+//organism if it has no offspring
 //	}
 //	population = nextPopulation;
 //}

--- a/Optimizer/SimpleOptimizer/SimpleOptimizer.cpp
+++ b/Optimizer/SimpleOptimizer/SimpleOptimizer.cpp
@@ -10,164 +10,199 @@
 
 #include "SimpleOptimizer.h"
 
-using namespace std;
+std::shared_ptr<ParameterLink<std::string>> SimpleOptimizer::selectionMethodPL =
+    Parameters::register_parameter(
+        "OPTIMIZER_SIMPLE-selectionMethod", (std::string) "Roulette()",
+        "how are parents selected? options: Roullette(),Tounament(size=VAL)");
+std::shared_ptr<ParameterLink<int>> SimpleOptimizer::numberParentsPL =
+    Parameters::register_parameter(
+        "OPTIMIZER_SIMPLE-numberParents", 1,
+        "number of parents used to produce offspring");
 
+std::shared_ptr<ParameterLink<std::string>> SimpleOptimizer::optimizeValuePL =
+    Parameters::register_parameter("OPTIMIZER_SIMPLE-optimizeValue",
+                                   (std::string) "DM_AVE[score]",
+                                   "value to optimize (MTree)");
+std::shared_ptr<ParameterLink<std::string>> SimpleOptimizer::surviveRatePL =
+    Parameters::register_parameter("OPTIMIZER_SIMPLE-surviveRate",
+                                   (std::string) "0",
+                                   "value between 0 and 1, likelyhood that an "
+                                   "organism will self (ignored if "
+                                   "numberParents = 1) (MTree)");
+std::shared_ptr<ParameterLink<std::string>> SimpleOptimizer::selfRatePL =
+    Parameters::register_parameter("OPTIMIZER_SIMPLE-selfRate",
+                                   (std::string) "0",
+                                   "value between 0 and 1, likelyhood that an "
+                                   "organism will survive (MTree)");
+std::shared_ptr<ParameterLink<std::string>> SimpleOptimizer::elitismCountPL =
+    Parameters::register_parameter("OPTIMIZER_SIMPLE-elitismCount",
+                                   (std::string) "1",
+                                   "number of mutated offspring "
+                                   "added to next population for "
+                                   "each elite organism (MTree)");
+std::shared_ptr<ParameterLink<std::string>> SimpleOptimizer::elitismRangePL =
+    Parameters::register_parameter(
+        "OPTIMIZER_SIMPLE-elitismRange", (std::string) "0",
+        "number of elite organisms (i.e. if 5, then best 5) (MTree)");
 
-shared_ptr<ParameterLink<string>> SimpleOptimizer::selectionMethodPL = Parameters::register_parameter("OPTIMIZER_SIMPLE-selectionMethod", (string) "Roulette()", "how are parents selected? options: Roullette(),Tounament(size=VAL)");
-shared_ptr<ParameterLink<int>> SimpleOptimizer::numberParentsPL = Parameters::register_parameter("OPTIMIZER_SIMPLE-numberParents", 1, "number of parents used to produce offspring");
+std::shared_ptr<ParameterLink<std::string>> SimpleOptimizer::nextPopSizePL =
+    Parameters::register_parameter(
+        "OPTIMIZER_SIMPLE-nextPopSize", (std::string) "0-1",
+        "size of population after optimization(MTree). -1 indicates use "
+        "current population size");
 
-shared_ptr<ParameterLink<string>> SimpleOptimizer::optimizeValuePL = Parameters::register_parameter("OPTIMIZER_SIMPLE-optimizeValue", (string) "DM_AVE[score]", "value to optimize (MTree)");
-shared_ptr<ParameterLink<string>> SimpleOptimizer::surviveRatePL = Parameters::register_parameter("OPTIMIZER_SIMPLE-surviveRate", (string) "0", "value between 0 and 1, likelyhood that an organism will self (ignored if numberParents = 1) (MTree)");
-shared_ptr<ParameterLink<string>> SimpleOptimizer::selfRatePL = Parameters::register_parameter("OPTIMIZER_SIMPLE-selfRate", (string) "0", "value between 0 and 1, likelyhood that an organism will survive (MTree)");
-shared_ptr<ParameterLink<string>> SimpleOptimizer::elitismCountPL = Parameters::register_parameter("OPTIMIZER_SIMPLE-elitismCount", (string) "1", "number of mutated offspring added to next population for each elite organism (MTree)");
-shared_ptr<ParameterLink<string>> SimpleOptimizer::elitismRangePL = Parameters::register_parameter("OPTIMIZER_SIMPLE-elitismRange", (string) "0", "number of elite organisms (i.e. if 5, then best 5) (MTree)");
+SimpleOptimizer::SimpleOptimizer(std::shared_ptr<ParametersTable> _PT)
+    : AbstractOptimizer(_PT) {
 
-shared_ptr<ParameterLink<string>> SimpleOptimizer::nextPopSizePL = Parameters::register_parameter("OPTIMIZER_SIMPLE-nextPopSize", (string)"0-1", "size of population after optimization(MTree). -1 indicates use current population size");
+  selectionMethod = selectionMethodPL->get(PT);
+  numberParents = numberParentsPL->get(PT);
 
-SimpleOptimizer::SimpleOptimizer(shared_ptr<ParametersTable> _PT) : AbstractOptimizer(_PT) {
-	
-	selectionMethod = selectionMethodPL->get(PT);
-	numberParents = numberParentsPL->get(PT);
-	
-	optimizeValueMT= stringToMTree(optimizeValuePL->get(PT));
-	surviveRateMT = stringToMTree(surviveRatePL->get(PT));
-	selfRateMT = stringToMTree(selfRatePL->get(PT));
-	elitismCountMT = stringToMTree(elitismCountPL->get(PT));
-	elitismRangeMT = stringToMTree(elitismRangePL->get(PT));
-	nextPopSizeMT = stringToMTree(nextPopSizePL->get(PT));
+  optimizeValueMT = stringToMTree(optimizeValuePL->get(PT));
+  surviveRateMT = stringToMTree(surviveRatePL->get(PT));
+  selfRateMT = stringToMTree(selfRatePL->get(PT));
+  elitismCountMT = stringToMTree(elitismCountPL->get(PT));
+  elitismRangeMT = stringToMTree(elitismRangePL->get(PT));
+  nextPopSizeMT = stringToMTree(nextPopSizePL->get(PT));
 
-	optimizeFormula = optimizeValueMT;
+  optimizeFormula = optimizeValueMT;
 
-	vector<string> selectorArgs;
-	stringstream ss(selectionMethod); // Turn the string into a stream.
-	string tok;
+  std::vector<std::string> selectorArgs;
+  std::stringstream ss(selectionMethod); // Turn the string into a stream.
+  std::string tok;
 
-	while (getline(ss, tok, '(')) {
-		selectorArgs.push_back(tok);
-	}
+  while (getline(ss, tok, '(')) {
+    selectorArgs.push_back(tok);
+  }
 
-	selectorArgs[1].pop_back();
-	//cout << "SimpleOptimizer method: " << selectorArgs[0] << "  " << selectorArgs[1] << endl;
-	//cout << selectorArgs.size() << endl;
-	if (selectorArgs[0] == "Tournament") {
-		selector = make_shared<TournamentSelector>(selectorArgs[1], this);
-	}
-	else if (selectorArgs[0] == "Roulette") {
-		selector = make_shared<RouletteSelector>(selectorArgs[1], this);
-	}
-	else {
-		cout << "  in SimpleOptimizer constructor, selector method \"" << selectionMethod << "\" is not known.\n  exiting..." << endl;
-		exit(1);
-	}
+  selectorArgs[1].pop_back();
+  // cout << "SimpleOptimizer method: " << selectorArgs[0] << "  " <<
+  // selectorArgs[1] << endl;
+  // cout << selectorArgs.size() << endl;
+  if (selectorArgs[0] == "Tournament") {
+    selector = std::make_shared<TournamentSelector>(selectorArgs[1], this);
+  } else if (selectorArgs[0] == "Roulette") {
+    selector = std::make_shared<RouletteSelector>(selectorArgs[1], this);
+  } else {
+    std::cout << "  in SimpleOptimizer constructor, selector method \""
+              << selectionMethod << "\" is not known.\n  exiting..."
+              << std::endl;
+    exit(1);
+  }
 
-	popFileColumns.clear();
-	popFileColumns.push_back("optimizeValue");
+  popFileColumns.clear();
+  popFileColumns.push_back("optimizeValue");
 }
 
-void SimpleOptimizer::optimize(vector<shared_ptr<Organism>> &population) {
-	oldPopulationSize = (int)population.size();
-	/////// MUST update to MTREE
-	nextPopulationTargetSize = (int)nextPopSizeMT->eval(PT)[0];
+void SimpleOptimizer::optimize(
+    std::vector<std::shared_ptr<Organism>> &population) {
+  oldPopulationSize = (int)population.size();
+  /////// MUST update to MTREE
+  nextPopulationTargetSize = (int)nextPopSizeMT->eval(PT)[0];
 
-	if (nextPopulationTargetSize == -1) {
-		nextPopulationTargetSize = population.size();
-	}
-	/////// MUST update to MTREE
+  if (nextPopulationTargetSize == -1) {
+    nextPopulationTargetSize = population.size();
+  }
+  /////// MUST update to MTREE
 
-	nextPopulationSize = 0;
+  nextPopulationSize = 0;
 
-	selfCount = 0;
-	eliteCount = 0;
-	surviveCount = 0;
-	
-	aveScore = 0;
-	maxScore = optimizeValueMT->eval(population[0]->dataMap, PT)[0];
-	minScore = maxScore;
-	
-	elites.clear();
-	scores.clear();
-	killList.clear();
+  selfCount = 0;
+  eliteCount = 0;
+  surviveCount = 0;
 
-	for (int i = 0; i < (int)population.size(); i++) {
-		if (Random::P(surviveRateMT->eval(population[i]->dataMap, PT)[0])) {
-			surviveCount++;
-			nextPopulationSize++;
-		}
-		else {
-			killList.insert(population[i]);
-		}
-		double opVal = optimizeValueMT->eval(population[i]->dataMap, PT)[0];
-		scores.push_back(opVal);
-		aveScore += opVal;
-		population[i]->dataMap.set("optimizeValue", opVal);
-		if (opVal > maxScore) {
-			maxScore = opVal;
-		}
-		if (opVal < minScore) {
-			minScore = opVal;
-		}
-	}
+  aveScore = 0;
+  maxScore = optimizeValueMT->eval(population[0]->dataMap, PT)[0];
+  minScore = maxScore;
 
-	aveScore /= oldPopulationSize;
+  elites.clear();
+  scores.clear();
+  killList.clear();
 
-	auto tempScores = scores;
-	int elitismRange = (int)elitismRangeMT->eval(PT)[0];
-	int elitismCount = (int)elitismCountMT->eval(PT)[0];
-	for (int i = 0; i < elitismRange; i++) { // get handles for elite orgs
-		elites.push_back(findGreatestInVector(tempScores));
-		tempScores[elites.back()] = minScore;
-	}
-	
-	/*
-	for (auto p : population) {
-		cout << optimizeValueMT->eval(p->dataMap, PT)[0] << ", ";
-	}
-	cout << endl;
-	for (auto elite : elites) {
-		cout << population[elite]->ID << ":" << optimizeValueMT->eval(population[elite]->dataMap, PT)[0] << "  ..." << endl;
-	}
-	*/
+  for (int i = 0; i < (int)population.size(); i++) {
+    if (Random::P(surviveRateMT->eval(population[i]->dataMap, PT)[0])) {
+      surviveCount++;
+      nextPopulationSize++;
+    } else {
+      killList.insert(population[i]);
+    }
+    double opVal = optimizeValueMT->eval(population[i]->dataMap, PT)[0];
+    scores.push_back(opVal);
+    aveScore += opVal;
+    population[i]->dataMap.set("optimizeValue", opVal);
+    if (opVal > maxScore) {
+      maxScore = opVal;
+    }
+    if (opVal < minScore) {
+      minScore = opVal;
+    }
+  }
 
-	// first add elitism offspring for each of the best elitismRange organisms (assuming there is room)
-	int currentElite = 0;
-	int currentCopy = 0;
-	while ((nextPopulationSize < nextPopulationTargetSize) && (currentElite < min(elitismRange,oldPopulationSize))) {
-		currentCopy = 0;
-		while ((nextPopulationSize < nextPopulationTargetSize) && (currentCopy < elitismCount)) {
-			population.push_back(population[elites[currentElite]]->makeMutatedOffspringFrom(population[elites[currentElite]]));
-			nextPopulationSize++;
-			eliteCount++;
-			currentCopy++;
-		}
-		currentElite++;
-	}
+  aveScore /= oldPopulationSize;
 
-	// now select parents for remainder of population
-	vector<shared_ptr<Organism>> parents;
-	while (nextPopulationSize < nextPopulationTargetSize) {  // while we have not filled up the next generation
-		if (numberParents == 1) {
-			auto parent = population[selector->select()];
-			population.push_back(parent->makeMutatedOffspringFrom(parent));
-		}
-		else {
-			parents.clear();
-			parents.push_back(population[selector->select()]);
-			if (Random::P(selfRateMT->eval(parents[0]->dataMap, PT)[0])) {
-				population.push_back(parents[0]->makeMutatedOffspringFrom(parents[0]));
-			}
-			else {
-				while ((int)parents.size() < numberParents) {
-					parents.push_back(population[selector->select()]);
-				}
-				population.push_back(parents[0]->makeMutatedOffspringFromMany(parents));
-			}
-		}
-		nextPopulationSize++;
-	}
-	cout << "max = " << to_string(maxScore) << "   ave = " << to_string(aveScore);
-	for (auto org : population) {
-		//org->dataMap.Set("Simple_numOffspring", org->offspringCount);
-	}
+  auto tempScores = scores;
+  int elitismRange = (int)elitismRangeMT->eval(PT)[0];
+  int elitismCount = (int)elitismCountMT->eval(PT)[0];
+  for (int i = 0; i < elitismRange; i++) { // get handles for elite orgs
+    elites.push_back(findGreatestInVector(tempScores));
+    tempScores[elites.back()] = minScore;
+  }
 
+  /*
+  for (auto p : population) {
+          cout << optimizeValueMT->eval(p->dataMap, PT)[0] << ", ";
+  }
+  cout << endl;
+  for (auto elite : elites) {
+          cout << population[elite]->ID << ":" <<
+  optimizeValueMT->eval(population[elite]->dataMap, PT)[0] << "  ..." << endl;
+  }
+  */
+
+  // first add elitism offspring for each of the best elitismRange organisms
+  // (assuming there is room)
+  int currentElite = 0;
+  int currentCopy = 0;
+  while ((nextPopulationSize < nextPopulationTargetSize) &&
+         (currentElite < std::min(elitismRange, oldPopulationSize))) {
+    currentCopy = 0;
+    while ((nextPopulationSize < nextPopulationTargetSize) &&
+           (currentCopy < elitismCount)) {
+      population.push_back(
+          population[elites[currentElite]]->makeMutatedOffspringFrom(
+              population[elites[currentElite]]));
+      nextPopulationSize++;
+      eliteCount++;
+      currentCopy++;
+    }
+    currentElite++;
+  }
+
+  // now select parents for remainder of population
+  std::vector<std::shared_ptr<Organism>> parents;
+  while (nextPopulationSize < nextPopulationTargetSize) { // while we have not
+                                                          // filled up the next
+                                                          // generation
+    if (numberParents == 1) {
+      auto parent = population[selector->select()];
+      population.push_back(parent->makeMutatedOffspringFrom(parent));
+    } else {
+      parents.clear();
+      parents.push_back(population[selector->select()]);
+      if (Random::P(selfRateMT->eval(parents[0]->dataMap, PT)[0])) {
+        population.push_back(parents[0]->makeMutatedOffspringFrom(parents[0]));
+      } else {
+        while ((int)parents.size() < numberParents) {
+          parents.push_back(population[selector->select()]);
+        }
+        population.push_back(parents[0]->makeMutatedOffspringFromMany(parents));
+      }
+    }
+    nextPopulationSize++;
+  }
+  std::cout << "max = " << std::to_string(maxScore)
+            << "   ave = " << std::to_string(aveScore);
+  for (auto org : population) {
+    // org->dataMap.Set("Simple_numOffspring", org->offspringCount);
+  }
 }
 

--- a/Optimizer/SimpleOptimizer/SimpleOptimizer.h
+++ b/Optimizer/SimpleOptimizer/SimpleOptimizer.h
@@ -8,7 +8,6 @@
 //     to view the full license, visit:
 //         github.com/Hintzelab/MABE/wiki/License
 
-
 #include "../AbstractOptimizer.h"
 #include "../../Utilities/MTree.h"
 
@@ -16,142 +15,169 @@
 #include <sstream>
 
 class SimpleOptimizer : public AbstractOptimizer {
- public:
+public:
+  static std::shared_ptr<ParameterLink<std::string>>
+      selectionMethodPL; // Roullette([Exp=1.05 or Lin=1]),Tounament(size=5)
+  static std::shared_ptr<ParameterLink<int>>
+      numberParentsPL; // number of parents (default 1, asexual)
 
-	static shared_ptr<ParameterLink<string>> selectionMethodPL; // Roullette([Exp=1.05 or Lin=1]),Tounament(size=5)
-	static shared_ptr<ParameterLink<int>> numberParentsPL; // number of parents (default 1, asexual)
+  static std::shared_ptr<ParameterLink<std::string>>
+      optimizeValuePL; // what value is used to generate
+  static std::shared_ptr<ParameterLink<std::string>>
+      surviveRatePL; // value between 0 and 1 chance to survive
+  static std::shared_ptr<ParameterLink<std::string>> selfRatePL; // value
+                                                                 // between 0
+                                                                 // and 1 chance
+                                                                 // to self (if
+                                                                 // more then
+                                                                 // one parent)
+  static std::shared_ptr<ParameterLink<std::string>>
+      elitismCountPL; // this number of organisms will reproduce asexualy (i.e.
+                      // copy w/ mutation)
+  static std::shared_ptr<ParameterLink<std::string>>
+      elitismRangePL; // best n organisms will each produce
 
-	static shared_ptr<ParameterLink<string>> optimizeValuePL; // what value is used to generate
-	static shared_ptr<ParameterLink<string>> surviveRatePL; // value between 0 and 1 chance to survive
-	static shared_ptr<ParameterLink<string>> selfRatePL; // value between 0 and 1 chance to self (if more then one parent)
-	static shared_ptr<ParameterLink<string>> elitismCountPL; // this number of organisms will reproduce asexualy (i.e. copy w/ mutation)
-	static shared_ptr<ParameterLink<string>> elitismRangePL; // best n organisms will each produce
+  static std::shared_ptr<ParameterLink<std::string>>
+      nextPopSizePL; // number of genomes in the population
 
-	static shared_ptr<ParameterLink<string>> nextPopSizePL;  // number of genomes in the population
+  std::string selectionMethod;
+  int numberParents;
 
-	string selectionMethod;
-	int numberParents;
+  ///
 
-	///
+  int oldPopulationSize;
+  int nextPopulationTargetSize;
+  int nextPopulationSize;
 
-	int oldPopulationSize;
-	int nextPopulationTargetSize;
-	int nextPopulationSize;
+  int selfCount;
+  int eliteCount;
+  int surviveCount;
 
-	int selfCount;
-	int eliteCount;
-	int surviveCount;
+  double aveScore;
+  double maxScore;
+  double minScore;
 
-	double aveScore;
-	double maxScore;
-	double minScore;
+  std::vector<int> elites;
+  std::vector<double> scores;
 
-	vector<int> elites;
-	vector<double> scores;
+  ///
+  class AbstractSelector {
+  public:
+    SimpleOptimizer *SO;
+    AbstractSelector() = default;
+    AbstractSelector(SimpleOptimizer *_SO) : SO(_SO){};
+    virtual int select() = 0;
+    virtual std::string getType() = 0;
+  };
 
-	///
-	class AbstractSelector {
-	public:
-		SimpleOptimizer *SO;
-		AbstractSelector() = default;
-		AbstractSelector(SimpleOptimizer *_SO) : SO(_SO){};
-		virtual int select() = 0;
-		virtual string getType() = 0;
-	};
+  class RouletteSelector : public AbstractSelector {
+  public:
+    RouletteSelector(std::string &argumentsString, SimpleOptimizer *_SO)
+        : AbstractSelector(_SO) {
+      // now decode arguments
+      std::vector<std::string> arguments;
+      std::stringstream ss(argumentsString); // Turn the string into a stream.
+      std::string tok;
 
-	class RouletteSelector : public AbstractSelector {
-	public:
-		RouletteSelector(string& argumentsString, SimpleOptimizer *_SO) : AbstractSelector(_SO) {
-			// now decode arguments
-			vector<string> arguments;
-			stringstream ss(argumentsString); // Turn the string into a stream.
-			string tok;
+      while (getline(ss, tok, ',')) {
+        arguments.push_back(tok);
+      }
+      if (arguments.size() > 0) {
+        std::cout << "  in RouletteSelector constructor, found arguments \""
+                  << argumentsString
+                  << "\" but Roulette takes no arguments.\n  exiting..."
+                  << std::endl;
+        exit(1);
+      }
+    }
 
-			while (getline(ss, tok, ',')) {
-				arguments.push_back(tok);
-			}
-			if (arguments.size() > 0) {
-				cout << "  in RouletteSelector constructor, found arguments \"" << argumentsString << "\" but Roulette takes no arguments.\n  exiting..." << endl;
-				exit(1);
-			}
-		}
+    virtual int select() override {
+      int pick;
+      do {
+        pick = Random::getIndex(SO->oldPopulationSize); // keep choosing a
+                                                        // random genome from
+                                                        // population until we
+                                                        // get one that's good
+                                                        // enough
+      } while (Random::getDouble(1) > (SO->scores[pick] / SO->maxScore));
+      return pick;
+    }
 
-		virtual int select() override {
-			int pick;
-			do {
-				pick = Random::getIndex(SO->oldPopulationSize);  //keep choosing a random genome from population until we get one that's good enough
-			} while (Random::getDouble(1) > (SO->scores[pick] / SO->maxScore));
-			return pick;
-		}
+    virtual std::string getType() override { return (std::string) "Roulette"; }
+  };
 
-		virtual string getType() override {
-			return (string)"Roulette";
-		}
-	};
+  class TournamentSelector : public AbstractSelector {
+  public:
+    int tournamentSize;
+    TournamentSelector(std::string &argumentsString, SimpleOptimizer *_SO)
+        : AbstractSelector(_SO) {
+      // now decode arguments
+      std::vector<std::string> arguments;
+      std::stringstream ss(argumentsString); // Turn the string into a stream.
+      std::string tok;
 
+      while (getline(ss, tok, ',')) {
+        arguments.push_back(tok);
+      }
+      for (auto arg : arguments) {
+        std::vector<std::string> parts;
+        std::stringstream ss(arg);
+        std::string tok;
+        while (getline(ss, tok, '=')) {
+          parts.push_back(tok);
+        }
+        if (parts[0] == "size") {
+          if (!load_value(parts[1], tournamentSize)) {
+            std::cout << "  in TournamentSelector constructor, got bad value "
+                         "for size \""
+                      << parts[1] << "\"\n  exiting..." << std::endl;
+            exit(1);
+          }
+        } else {
+          std::cout << "  in TournamentSelector constructor, found unknown "
+                       "argument pair \""
+                    << parts[0] << "=" << parts[1] << "\"\n  exiting..."
+                    << std::endl;
+          exit(1);
+        }
+      }
+    }
 
-	class TournamentSelector : public AbstractSelector {
-	public:
-		int tournamentSize;
-		TournamentSelector(string& argumentsString, SimpleOptimizer *_SO) : AbstractSelector(_SO) {
-			// now decode arguments
-			vector<string> arguments;
-			stringstream ss(argumentsString); // Turn the string into a stream.
-			string tok;
+    virtual int select() override {
+      int winner, challanger;
+      winner = Random::getIndex(SO->oldPopulationSize);
+      for (int i = 0; i < tournamentSize - 1; i++) {
+        challanger = Random::getIndex(SO->oldPopulationSize);
+        // cout << tournamentSize << " " <<i << "  " <<
+        // challanger<<"("<<SO.scores[challanger] << "),winner(" <<
+        // SO.scores[winner] << ")";
+        if (SO->scores[challanger] > SO->scores[winner]) {
+          // cout << " *";
+          winner = challanger;
+        }
+        // cout << endl;
+      }
+      return winner;
+    }
 
-			while (getline(ss, tok, ',')) {
-				arguments.push_back(tok);
-			}
-			for (auto arg : arguments) {
-				vector<string> parts;
-				stringstream ss(arg);
-				string tok;
-				while (getline(ss, tok, '=')) {
-					parts.push_back(tok);
-				}
-				if (parts[0] == "size") {
-					if (!load_value(parts[1], tournamentSize)) {
-						cout << "  in TournamentSelector constructor, got bad value for size \"" << parts[1] << "\"\n  exiting..." << endl;
-						exit(1);
-					}
-				}
-				else {
-					cout << "  in TournamentSelector constructor, found unknown argument pair \"" << parts[0] << "=" << parts[1] << "\"\n  exiting..." << endl;
-					exit(1);
-				}
-			}
-		}
+    virtual std::string getType() override {
+      return (std::string) "Tournament";
+    }
+  };
 
-		virtual int select() override {
-			int winner, challanger;
-			winner = Random::getIndex(SO->oldPopulationSize);
-			for (int i = 0; i < tournamentSize - 1; i++) {
-				challanger = Random::getIndex(SO->oldPopulationSize);
-				//cout << tournamentSize << " " <<i << "  " << challanger<<"("<<SO.scores[challanger] << "),winner(" << SO.scores[winner] << ")";
-				if (SO->scores[challanger] > SO->scores[winner]) {
-					//cout << " *";
-					winner = challanger;
-				}
-				//cout << endl;
-			}
-			return winner;
-		}
+  std::shared_ptr<AbstractSelector> selector;
 
-		virtual string getType() override {
-			return (string)"Tournament";
-		}
-	};
+  std::shared_ptr<Abstract_MTree> optimizeValueMT, surviveRateMT, selfRateMT,
+      elitismCountMT, elitismRangeMT, nextPopSizeMT;
 
-	shared_ptr<AbstractSelector> selector;
+  SimpleOptimizer(std::shared_ptr<ParametersTable> _PT = nullptr);
 
-	shared_ptr<Abstract_MTree> optimizeValueMT, surviveRateMT, selfRateMT, elitismCountMT, elitismRangeMT, nextPopSizeMT;
+  virtual void
+  optimize(std::vector<std::shared_ptr<Organism>> &population) override;
 
-	SimpleOptimizer(shared_ptr<ParametersTable> _PT = nullptr);
-	
-	virtual void optimize(vector<shared_ptr<Organism>> &population) override;
-
-	//virtual string maxValueName() override {
-	//	return (PT == nullptr) ? optimizeValuePL->lookup() : PT->lookupString("OPTIMIZER_Simple-optimizeValue");
-	//}
+  // virtual string maxValueName() override {
+  //	return (PT == nullptr) ? optimizeValuePL->lookup() :
+  //PT->lookupString("OPTIMIZER_Simple-optimizeValue");
+  //}
 };
 

--- a/Organism/Organism.cpp
+++ b/Organism/Organism.cpp
@@ -18,327 +18,371 @@
 #include "../Utilities/Utilities.h"
 
 /* Organism class (the one we expect to be used most of the time
- * has a genome, a brain, tools for lineage and ancestor tracking (for snapshot data saving method)
+ * has a genome, a brain, tools for lineage and ancestor tracking (for snapshot
+ * data saving method)
  */
 
-int Organism::organismIDCounter = -1;  // every organism will get a unique ID
+int Organism::organismIDCounter = -1; // every organism will get a unique ID
 
 // this is used to hold the most recent common ancestor
 
-void Organism::initOrganism(shared_ptr<ParametersTable> _PT) {
-	PT = _PT;
-	ID = registerOrganism();
-	alive = true;
-	offspringCount = 0;  // because it's alive;
-	timeOfBirth = Global::update;  // happy birthday!
-	timeOfDeath = -1;  // still alive
-	dataMap.set("ID", ID);
-	dataMap.set("alive", alive);
-	dataMap.set("timeOfBirth", timeOfBirth);
+void Organism::initOrganism(std::shared_ptr<ParametersTable> _PT) {
+  PT = _PT;
+  ID = registerOrganism();
+  alive = true;
+  offspringCount = 0;           // because it's alive;
+  timeOfBirth = Global::update; // happy birthday!
+  timeOfDeath = -1;             // still alive
+  dataMap.set("ID", ID);
+  dataMap.set("alive", alive);
+  dataMap.set("timeOfBirth", timeOfBirth);
 }
-
 
 /*
  * create an empty organism - it must be filled somewhere else.
  * parents is left empty (this is organism has no parents!)
  */
-Organism::Organism(shared_ptr<ParametersTable> _PT) {
-	initOrganism(_PT);
-	ancestors.insert(ID);  // it is it's own Ancestor for data tracking purposes
-	snapshotAncestors.insert(ID);
+Organism::Organism(std::shared_ptr<ParametersTable> _PT) {
+  initOrganism(_PT);
+  ancestors.insert(ID); // it is it's own Ancestor for data tracking purposes
+  snapshotAncestors.insert(ID);
 }
 
 /*
-* create a new organism given genomes and brains - the grnome and brains passed with be installed as is (i.e. NOT copied)
-* it is assumed that either this organism will never by used (it will serve as a template), or the brains have already been built elsewhere
-* parents is set left unset/nullptr (no parents), and ancestor is set to self (this organism is the result of adigigenesis!)
+* create a new organism given genomes and brains - the grnome and brains passed
+* with be installed as is (i.e. NOT copied)
+* it is assumed that either this organism will never by used (it will serve as a
+* template), or the brains have already been built elsewhere
+* parents is set left unset/nullptr (no parents), and ancestor is set to self
+* (this organism is the result of adigigenesis!)
 */
-Organism::Organism(unordered_map<string, shared_ptr<AbstractGenome>>& _genomes, unordered_map<string, shared_ptr<AbstractBrain>>& _brains, shared_ptr<ParametersTable> _PT) {
-	initOrganism(_PT);
-	
-	genomes = _genomes;
+Organism::Organism(
+    std::unordered_map<std::string, std::shared_ptr<AbstractGenome>> &_genomes,
+    std::unordered_map<std::string, std::shared_ptr<AbstractBrain>> &_brains,
+    std::shared_ptr<ParametersTable> _PT) {
+  initOrganism(_PT);
 
-	for (auto genome : genomes) { // collect stats from genomes
-		string prefix;
-		(genome.first == "root::") ? prefix = "" : prefix = genome.first;
-		dataMap.merge(genome.second->getStats(prefix));
-	}
+  genomes = _genomes;
 
-	brains = _brains;
+  for (auto genome : genomes) { // collect stats from genomes
+    std::string prefix;
+    (genome.first == "root::") ? prefix = "" : prefix = genome.first;
+    dataMap.merge(genome.second->getStats(prefix));
+  }
 
-	for (auto brain : _brains) { // collect stats from brains
-		string prefix;
-		(brain.first == "root::") ? prefix = "" : prefix = brain.first;
-		dataMap.merge(brain.second->getStats(prefix));
-	}
+  brains = _brains;
 
-	if (genomes.count("root::") == 0) {
-		genome = nullptr;
-	}
-	else {
-		genome = genomes["root::"];
-	}
+  for (auto brain : _brains) { // collect stats from brains
+    std::string prefix;
+    (brain.first == "root::") ? prefix = "" : prefix = brain.first;
+    dataMap.merge(brain.second->getStats(prefix));
+  }
 
-	if (brains.count("root::") == 0) {
-		brain = nullptr;
-	}
-	else {
-		brain = brains["root::"];
-	}
+  if (genomes.count("root::") == 0) {
+    genome = nullptr;
+  } else {
+    genome = genomes["root::"];
+  }
 
-	ancestors.insert(ID);  // it is it's own Ancestor for data tracking purposes
-	snapshotAncestors.insert(ID);
+  if (brains.count("root::") == 0) {
+    brain = nullptr;
+  } else {
+    brain = brains["root::"];
+  }
+
+  ancestors.insert(ID); // it is it's own Ancestor for data tracking purposes
+  snapshotAncestors.insert(ID);
 }
 
 /*
-* create a new organism given a single parent, genomes and brains - the grnome and brains passed with be installed as is (i.e. NOT copied)
-* it is assumed that either this organism will never by used (it will serve as a template), or the brains have already been built elsewhere
+* create a new organism given a single parent, genomes and brains - the grnome
+* and brains passed with be installed as is (i.e. NOT copied)
+* it is assumed that either this organism will never by used (it will serve as a
+* template), or the brains have already been built elsewhere
 */
-Organism::Organism(shared_ptr<Organism> from, unordered_map<string, shared_ptr<AbstractGenome>>& _genomes, unordered_map<string, shared_ptr<AbstractBrain>>& _brains, shared_ptr<ParametersTable> _PT) {
-	initOrganism(_PT);
+Organism::Organism(
+    std::shared_ptr<Organism> from,
+    std::unordered_map<std::string, std::shared_ptr<AbstractGenome>> &_genomes,
+    std::unordered_map<std::string, std::shared_ptr<AbstractBrain>> &_brains,
+    std::shared_ptr<ParametersTable> _PT) {
+  initOrganism(_PT);
 
-	genomes = _genomes;
+  genomes = _genomes;
 
-	for (auto genome : genomes) { // collect stats from genomes
-		string prefix;
-		(genome.first == "root::") ? prefix = "" : prefix = genome.first;
-		dataMap.merge(genome.second->getStats(prefix));
-	}
+  for (auto genome : genomes) { // collect stats from genomes
+    std::string prefix;
+    (genome.first == "root::") ? prefix = "" : prefix = genome.first;
+    dataMap.merge(genome.second->getStats(prefix));
+  }
 
-	brains = _brains;
+  brains = _brains;
 
-	for (auto brain : _brains) { // collect stats from brains
-		string prefix;
-		(brain.first == "root::") ? prefix = "" : prefix = brain.first;
-		dataMap.merge(brain.second->getStats(prefix));
-	}
+  for (auto brain : _brains) { // collect stats from brains
+    std::string prefix;
+    (brain.first == "root::") ? prefix = "" : prefix = brain.first;
+    dataMap.merge(brain.second->getStats(prefix));
+  }
 
-	if (genomes.count("root::") == 0) {
-		genome = nullptr;
-	}
-	else {
-		genome = genomes["root::"];
-	}
+  if (genomes.count("root::") == 0) {
+    genome = nullptr;
+  } else {
+    genome = genomes["root::"];
+  }
 
-	if (brains.count("root::") == 0) {
-		brain = nullptr;
-	}
-	else {
-		brain = brains["root::"];
-	}
+  if (brains.count("root::") == 0) {
+    brain = nullptr;
+  } else {
+    brain = brains["root::"];
+  }
 
-	parents.push_back(from);
-	from->offspringCount++;  // this parent has an(other) offspring
-	for (auto ancestorID : from->ancestors) {
-		ancestors.insert(ancestorID);  // union all parents ancestors into this organisms ancestor set.
-	}
-	for (auto ancestorID : from->snapshotAncestors) {
-		snapshotAncestors.insert(ancestorID);  // union all parents ancestors into this organisms ancestor set.
-	}
+  parents.push_back(from);
+  from->offspringCount++; // this parent has an(other) offspring
+  for (auto ancestorID : from->ancestors) {
+    ancestors.insert(ancestorID); // union all parents ancestors into this
+                                  // organisms ancestor set.
+  }
+  for (auto ancestorID : from->snapshotAncestors) {
+    snapshotAncestors.insert(ancestorID); // union all parents ancestors into
+                                          // this organisms ancestor set.
+  }
 }
 
 /*
-* create a new organism given a list of parents, genomes and brains - the grnome and brains passed with be installed as is (i.e. NOT copied)
-* it is assumed that either this organism will never by used (it will serve as a template), or the brains have already been built elsewhere
+* create a new organism given a list of parents, genomes and brains - the grnome
+* and brains passed with be installed as is (i.e. NOT copied)
+* it is assumed that either this organism will never by used (it will serve as a
+* template), or the brains have already been built elsewhere
 */
-Organism::Organism(vector<shared_ptr<Organism>> from, unordered_map<string, shared_ptr<AbstractGenome>>& _genomes, unordered_map<string, shared_ptr<AbstractBrain>>& _brains, shared_ptr<ParametersTable> _PT) {
-	initOrganism(_PT);
+Organism::Organism(
+    std::vector<std::shared_ptr<Organism>> from,
+    std::unordered_map<std::string, std::shared_ptr<AbstractGenome>> &_genomes,
+    std::unordered_map<std::string, std::shared_ptr<AbstractBrain>> &_brains,
+    std::shared_ptr<ParametersTable> _PT) {
+  initOrganism(_PT);
 
-	genomes = _genomes;
+  genomes = _genomes;
 
-	for (auto genome : genomes) { // collect stats from genomes
-		string prefix;
-		(genome.first == "root::") ? prefix = "" : prefix = genome.first;
-		dataMap.merge(genome.second->getStats(prefix));
-	}
+  for (auto genome : genomes) { // collect stats from genomes
+    std::string prefix;
+    (genome.first == "root::") ? prefix = "" : prefix = genome.first;
+    dataMap.merge(genome.second->getStats(prefix));
+  }
 
-	brains = _brains;
+  brains = _brains;
 
-	for (auto brain : _brains) { // collect stats from brains
-		string prefix;
-		(brain.first == "root::") ? prefix = "" : prefix = brain.first;
-		dataMap.merge(brain.second->getStats(prefix));
-	}
+  for (auto brain : _brains) { // collect stats from brains
+    std::string prefix;
+    (brain.first == "root::") ? prefix = "" : prefix = brain.first;
+    dataMap.merge(brain.second->getStats(prefix));
+  }
 
-	if (genomes.count("root::") == 0) {
-		genome = nullptr;
-	}
-	else {
-		genome = genomes["root::"];
-	}
+  if (genomes.count("root::") == 0) {
+    genome = nullptr;
+  } else {
+    genome = genomes["root::"];
+  }
 
-	if (brains.count("root::") == 0) {
-		brain = nullptr;
-	}
-	else {
-		brain = brains["root::"];
-	}
+  if (brains.count("root::") == 0) {
+    brain = nullptr;
+  } else {
+    brain = brains["root::"];
+  }
 
-	for (auto parent : from) {
-		parents.push_back(parent);  // add this parent to the parents set
-		parent->offspringCount++;  // this parent has an(other) offspring
-		for (auto ancestorID : parent->ancestors) {
-			ancestors.insert(ancestorID);  // union all parents ancestors into this organisms ancestor set
-		}
-		for (auto ancestorID : parent->snapshotAncestors) {
-			snapshotAncestors.insert(ancestorID);  // union all parents ancestors into this organisms ancestor set.
-		}
-	}
+  for (auto parent : from) {
+    parents.push_back(parent); // add this parent to the parents set
+    parent->offspringCount++;  // this parent has an(other) offspring
+    for (auto ancestorID : parent->ancestors) {
+      ancestors.insert(ancestorID); // union all parents ancestors into this
+                                    // organisms ancestor set
+    }
+    for (auto ancestorID : parent->snapshotAncestors) {
+      snapshotAncestors.insert(ancestorID); // union all parents ancestors into
+                                            // this organisms ancestor set.
+    }
+  }
 }
 
 // this function provides a unique ID value for every org
 int Organism::registerOrganism() {
-	return organismIDCounter++;;
+  return organismIDCounter++;
+  ;
 }
 
 Organism::~Organism() {
-	for (auto parent : parents) {
-		parent->offspringCount--;  // this parent has one less child in memory
-	}
-	parents.clear();
+  for (auto parent : parents) {
+    parent->offspringCount--; // this parent has one less child in memory
+  }
+  parents.clear();
 }
 
 /*
  * called to kill an organism. Set alive to false
  */
 void Organism::kill() {
-	alive = false;
-	timeOfDeath = Global::update;
-	if (!trackOrganism) { // if the archivist is not tracking is organism, we can clear it's genomes and brains.
-		genome = nullptr;
-		brain = nullptr;
-		genomes.clear();
-		brains.clear();
-	}
+  alive = false;
+  timeOfDeath = Global::update;
+  if (!trackOrganism) { // if the archivist is not tracking is organism, we can
+                        // clear it's genomes and brains.
+    genome = nullptr;
+    brain = nullptr;
+    genomes.clear();
+    brains.clear();
+  }
 }
 
-shared_ptr<Organism> Organism::makeMutatedOffspringFrom(shared_ptr<Organism> from) {
+std::shared_ptr<Organism>
+Organism::makeMutatedOffspringFrom(std::shared_ptr<Organism> from) {
 
-	unordered_map<string, shared_ptr<AbstractGenome>> newGenomes;
-	unordered_map<string, shared_ptr<AbstractBrain>> newBrains;
+  std::unordered_map<std::string, std::shared_ptr<AbstractGenome>> newGenomes;
+  std::unordered_map<std::string, std::shared_ptr<AbstractBrain>> newBrains;
 
-	for (auto genome : from->genomes) {
-		newGenomes[genome.first] = genome.second->makeMutatedGenomeFrom(genome.second);
-	}
+  for (auto genome : from->genomes) {
+    newGenomes[genome.first] =
+        genome.second->makeMutatedGenomeFrom(genome.second);
+  }
 
-	for (auto brain : from->brains) {
-		newBrains[brain.first] = brain.second->makeBrainFrom(brain.second,newGenomes);
-		newBrains[brain.first]->mutate();
-	}
-	
-	return make_shared<Organism>(from, newGenomes, newBrains, PT);
+  for (auto brain : from->brains) {
+    newBrains[brain.first] =
+        brain.second->makeBrainFrom(brain.second, newGenomes);
+    newBrains[brain.first]->mutate();
+  }
+
+  return std::make_shared<Organism>(from, newGenomes, newBrains, PT);
 }
 
-shared_ptr<Organism> Organism::makeMutatedOffspringFromMany(vector<shared_ptr<Organism>> from) {
+std::shared_ptr<Organism> Organism::makeMutatedOffspringFromMany(
+    std::vector<std::shared_ptr<Organism>> from) {
 
-	unordered_map<string, shared_ptr<AbstractGenome>> newGenomes;
-	unordered_map<string, shared_ptr<AbstractBrain>> newBrains;
+  std::unordered_map<std::string, std::shared_ptr<AbstractGenome>> newGenomes;
+  std::unordered_map<std::string, std::shared_ptr<AbstractBrain>> newBrains;
 
-	for (auto genome : from[0]->genomes) {
-		vector<shared_ptr<AbstractGenome>> parentGenomes; // make a list of parents genomes
-		for (auto p : from) {
-			parentGenomes.push_back(p->genomes[genome.first]);
-		}
-		newGenomes[genome.first] = genome.second->makeMutatedGenomeFromMany(parentGenomes);
+  for (auto genome : from[0]->genomes) {
+    std::vector<std::shared_ptr<AbstractGenome>>
+        parentGenomes; // make a list of parents genomes
+    for (auto p : from) {
+      parentGenomes.push_back(p->genomes[genome.first]);
+    }
+    newGenomes[genome.first] =
+        genome.second->makeMutatedGenomeFromMany(parentGenomes);
+  }
 
+  for (auto brain : from[0]->brains) {
+    std::vector<std::shared_ptr<AbstractBrain>>
+        parentBrains; // make a list of parents genomes
+    for (auto p : from) {
+      parentBrains.push_back(p->brains[brain.first]);
+    }
 
-	}
+    newBrains[brain.first] =
+        brain.second->makeBrainFromMany(parentBrains, newGenomes);
+    newBrains[brain.first]->mutate();
+  }
 
-	for (auto brain : from[0]->brains) {
-		vector<shared_ptr<AbstractBrain>> parentBrains; // make a list of parents genomes
-		for (auto p : from) {
-			parentBrains.push_back(p->brains[brain.first]);
-		}
-
-		newBrains[brain.first] = brain.second->makeBrainFromMany(parentBrains, newGenomes);
-		newBrains[brain.first]->mutate();
-	}
-
-	return make_shared<Organism>(from, newGenomes, newBrains, PT);
+  return std::make_shared<Organism>(from, newGenomes, newBrains, PT);
 }
 
 /*
- * Given a genome return a list of Organisms containing this Organism and all if this Organisms ancestors ordered oldest first
- * it will fail if any organism in the LOD has more then one parent. (!not for sexual reproduction!)
+ * Given a genome return a list of Organisms containing this Organism and all if
+ * this Organisms ancestors ordered oldest first
+ * it will fail if any organism in the LOD has more then one parent. (!not for
+ * sexual reproduction!)
  */
-vector<shared_ptr<Organism>> Organism::getLOD(shared_ptr<Organism> org) {
-	vector<shared_ptr<Organism>> list;
+std::vector<std::shared_ptr<Organism>>
+Organism::getLOD(std::shared_ptr<Organism> org) {
+  std::vector<std::shared_ptr<Organism>> list;
 
-	list.push_back(org);  // add this organism to the front of the LOD list
-	while (org->parents.size() == 1) {  // while the current org has one and only one parent
-		org = org->parents[0];  // move to the next ancestor (since there is only one parent it is the element in the first position).
-		list.push_back(org);  // add that ancestor to the front of the LOD list
-	}
-	reverse(list.begin(), list.end());
-	for (size_t i = 0; i < list.size(); i++) {
-	}
-	if (org->parents.size() > 1) {  // if more than one parent we have a problem!
-		cout << "In Organism::getLOD(shared_ptr<Organism> org)\n Looks like you have enabled sexual reproduction.\nLOD only works with asexual populations. i.e. an offspring may have at most one parent.\nExiting!\n";
-		exit(1);
-	}
-	return list;
+  list.push_back(org); // add this organism to the front of the LOD list
+  while (org->parents.size() ==
+         1) {              // while the current org has one and only one parent
+    org = org->parents[0]; // move to the next ancestor (since there is only one
+                           // parent it is the element in the first position).
+    list.push_back(org);   // add that ancestor to the front of the LOD list
+  }
+  reverse(list.begin(), list.end());
+  for (size_t i = 0; i < list.size(); i++) {
+  }
+  if (org->parents.size() > 1) { // if more than one parent we have a problem!
+    std::cout
+        << "In Organism::getLOD(shared_ptr<Organism> org)\n Looks like you "
+           "have enabled sexual reproduction.\nLOD only works with asexual "
+           "populations. i.e. an offspring may have at most one "
+           "parent.\nExiting!\n";
+    exit(1);
+  }
+  return list;
 }
 
 /*
  * find the Most Recent Common Ancestor
- * uses getLOD to get a list of ancestors (oldest first). seaches the list for the first ancestor with a referenceCounter > 1
+ * uses getLOD to get a list of ancestors (oldest first). seaches the list for
+ * the first ancestor with a referenceCounter > 1
  * that is the first reference counter with more then one offspring.
  * If none are found, then return "from"
- * Note: a currently active genome has a referenceCounter = 1 (it has not reproduced yet, it only has 1 for it's self)
- *       a dead Organism with a referenceCounter = 0 will not be in the LOD (it has no offspring and will have been pruned)
+ * Note: a currently active genome has a referenceCounter = 1 (it has not
+ * reproduced yet, it only has 1 for it's self)
+ *       a dead Organism with a referenceCounter = 0 will not be in the LOD (it
+ * has no offspring and will have been pruned)
  *       a dead Organism with a referenceCounter = 1 has only one offspring.
- *       a dead Organism with a referenceCounter > 1 has more then one spring with surviving lines of decent.
+ *       a dead Organism with a referenceCounter > 1 has more then one spring
+ * with surviving lines of decent.
  */
-shared_ptr<Organism> Organism::getMostRecentCommonAncestor(shared_ptr<Organism> org) {
-	vector<shared_ptr<Organism>> LOD = getLOD(org);  // get line of decent parent "parent"
-	for (auto org : LOD) {  // starting at the oldest parent, moving to the youngest
-		if (org->offspringCount > 1)  // the first (oldest) ancestor with more then one surviving offspring
-			return org;
-	}
-	return org;  // a currently active genome will have referenceCounter = 1 but may be the Most Recent Common Ancestor
+std::shared_ptr<Organism>
+Organism::getMostRecentCommonAncestor(std::shared_ptr<Organism> org) {
+  std::vector<std::shared_ptr<Organism>> LOD =
+      getLOD(org); // get line of decent parent "parent"
+  for (auto org :
+       LOD) { // starting at the oldest parent, moving to the youngest
+    if (org->offspringCount >
+        1) // the first (oldest) ancestor with more then one surviving offspring
+      return org;
+  }
+  return org; // a currently active genome will have referenceCounter = 1 but
+              // may be the Most Recent Common Ancestor
 }
-shared_ptr<Organism> Organism::getMostRecentCommonAncestor(vector<shared_ptr<Organism>> LOD) {
-	for (auto org : LOD) {  // starting at the oldest parent, moving to the youngest
-		if (org->offspringCount > 1)  // the first (oldest) ancestor with more then one surviving offspring
-			return org;
-	}
-	return LOD.back();  // a currently active genome will have referenceCounter = 1 but may be the Most Recent Common Ancestor
+std::shared_ptr<Organism> Organism::getMostRecentCommonAncestor(
+    std::vector<std::shared_ptr<Organism>> LOD) {
+  for (auto org :
+       LOD) { // starting at the oldest parent, moving to the youngest
+    if (org->offspringCount >
+        1) // the first (oldest) ancestor with more then one surviving offspring
+      return org;
+  }
+  return LOD.back(); // a currently active genome will have referenceCounter = 1
+                     // but may be the Most Recent Common Ancestor
 }
 
+std::shared_ptr<Organism>
+Organism::makeCopy(std::shared_ptr<ParametersTable> _PT) {
+  auto newOrg = std::make_shared<Organism>(_PT);
+  for (auto genome : genomes) {
+    newOrg->genomes[genome.first] = genome.second->makeCopy(genome.second->PT);
+  }
+  for (auto brain : brains) {
+    newOrg->brains[brain.first] = brain.second->makeCopy(brain.second->PT);
+  }
 
-shared_ptr<Organism> Organism::makeCopy(shared_ptr<ParametersTable> _PT) {
-	auto newOrg = make_shared<Organism>(_PT);
-	for (auto genome : genomes) {
-		newOrg->genomes[genome.first] = genome.second->makeCopy(genome.second->PT);
-	}
-	for (auto brain : brains) {
-		newOrg->brains[brain.first] = brain.second->makeCopy(brain.second->PT);
-	}
+  if (newOrg->genomes.count("root::") == 0) {
+    newOrg->genome = nullptr;
+  } else {
+    newOrg->genome = newOrg->genomes["root::"];
+  }
 
-	if (newOrg->genomes.count("root::") == 0) {
-		newOrg->genome = nullptr;
-	}
-	else {
-		newOrg->genome = newOrg->genomes["root::"];
-	}
+  if (newOrg->brains.count("root::") == 0) {
+    newOrg->brain = nullptr;
+  } else {
+    newOrg->brain = newOrg->brains["root::"];
+  }
 
-	if (newOrg->brains.count("root::") == 0) {
-		newOrg->brain = nullptr;
-	}
-	else {
-		newOrg->brain = newOrg->brains["root::"];
-	}
-
-	newOrg->dataMap = dataMap;
-	newOrg->snapShotDataMaps = snapShotDataMaps;
-	newOrg->offspringCount = offspringCount;
-	newOrg->parents = parents;
-	for (auto parent : parents) {
-		parent->offspringCount++;
-	}
-	newOrg->ancestors = ancestors;
-	newOrg->timeOfBirth = timeOfBirth;
-	newOrg->timeOfDeath = timeOfDeath;
-	newOrg->alive = alive;
-	return newOrg;
+  newOrg->dataMap = dataMap;
+  newOrg->snapShotDataMaps = snapShotDataMaps;
+  newOrg->offspringCount = offspringCount;
+  newOrg->parents = parents;
+  for (auto parent : parents) {
+    parent->offspringCount++;
+  }
+  newOrg->ancestors = ancestors;
+  newOrg->timeOfBirth = timeOfBirth;
+  newOrg->timeOfDeath = timeOfDeath;
+  newOrg->alive = alive;
+  return newOrg;
 }

--- a/Organism/Organism.h
+++ b/Organism/Organism.h
@@ -20,71 +20,114 @@
 #include "../Utilities/Data.h"
 #include "../Utilities/Parameters.h"
 
-using namespace std;
-
 class Organism {
- private:
-	static int organismIDCounter;  // used to issue unique ids to Genomes
-	int registerOrganism();  // get an Organism_id (uses organismIDCounter)
+private:
+  static int organismIDCounter; // used to issue unique ids to Genomes
+  int registerOrganism();       // get an Organism_id (uses organismIDCounter)
 
- public:
-	DataMap dataMap;  // holds all data (genome size, score, world data, etc.)
-	map<int, DataMap> snapShotDataMaps;  // Used only with SnapShot with Delay (SSwD) stores contents of dataMap when an ouput interval is reached so that
-	// after the delay we have the correct data for the given time. key is 'update'. This possibly should be wrapped into Archivist.
+public:
+  DataMap dataMap; // holds all data (genome size, score, world data, etc.)
+  std::map<int, DataMap> snapShotDataMaps; // Used only with SnapShot with Delay
+  // (SSwD) stores contents of dataMap when
+  // an ouput interval is reached so that
+  // after the delay we have the correct data for the given time. key is
+  // 'update'. This possibly should be wrapped into Archivist.
 
-	shared_ptr<AbstractGenome> genome = nullptr;
-	shared_ptr<AbstractBrain> brain = nullptr;
-	shared_ptr<ParametersTable> PT;
+  std::shared_ptr<AbstractGenome> genome = nullptr;
+  std::shared_ptr<AbstractBrain> brain = nullptr;
+  std::shared_ptr<ParametersTable> PT;
 
-	unordered_map<string, shared_ptr<AbstractGenome>> genomes;
-	unordered_map<string, shared_ptr<AbstractBrain>> brains;
+  std::unordered_map<std::string, std::shared_ptr<AbstractGenome>> genomes;
+  std::unordered_map<std::string, std::shared_ptr<AbstractBrain>> brains;
 
-	int offspringCount;
+  int offspringCount;
 
-	vector<shared_ptr<Organism>> parents;  // parents are pointers to parents of this organism. In asexual populations this will have one element
-	//unordered_set<int> genomeAncestors;  // list of the IDs of organisms in the last genome file who are ancestors of this organism (genomes saved on genome interval)
-	unordered_set<int> ancestors;  // list of the IDs of organisms in the last data files who are ancestors of this organism (i.e. all files saved on data interval)
-	unordered_set<int> snapshotAncestors;  // like ancestors, but for snapshot files.
+  std::vector<std::shared_ptr<Organism>>
+      parents; // parents are pointers to parents of
+               // this organism. In asexual populations
+               // this will have one element
+  // unordered_set<int> genomeAncestors;  // list of the IDs of organisms in the
+  // last genome file who are ancestors of this organism (genomes saved on
+  // genome interval)
+  std::unordered_set<int>
+      ancestors; // list of the IDs of organisms in the last data
+                 // files who are ancestors of this organism
+                 // (i.e. all files saved on data interval)
+  std::unordered_set<int>
+      snapshotAncestors; // like ancestors, but for snapshot files.
 
-	int ID;
-	int timeOfBirth;  // the time this organism was made
-	int timeOfDeath;  // the time this organism stopped being alive (this organism may be stored for archival reasons)
+  int ID;
+  int timeOfBirth; // the time this organism was made
+  int timeOfDeath; // the time this organism stopped being alive (this organism
+                   // may be stored for archival reasons)
 
-	bool alive;  // is this organism alive (1) or dead (0)
-	bool trackOrganism = false; // if false, genome will be deleted when organism dies.
+  bool alive; // is this organism alive (1) or dead (0)
+  bool trackOrganism =
+      false; // if false, genome will be deleted when organism dies.
 
-	void initOrganism(shared_ptr<ParametersTable> _PT);
+  void initOrganism(std::shared_ptr<ParametersTable> _PT);
 
-	Organism() = delete; 
-	Organism(shared_ptr<ParametersTable> _PT = nullptr);  // make an empty organism
-	//Organism(shared_ptr<AbstractGenome> _genome, shared_ptr<AbstractBrain> _brain, shared_ptr<ParametersTable> _PT = nullptr);  // make a parentless organism with a genome, and a brain
-	//Organism(shared_ptr<Organism> from, shared_ptr<AbstractGenome> _genome, shared_ptr<AbstractBrain> _brain, shared_ptr<ParametersTable> _PT = nullptr);  // make an organism with one parent, a genome and a brain determined from the parents brain type.
-	//Organism(const vector<shared_ptr<Organism>> from, shared_ptr<AbstractGenome> _genome, shared_ptr<AbstractBrain> _brain, shared_ptr<ParametersTable> _PT = nullptr);  // make a organism with many parents, a genome, and a brain determined from the parents brain type.
+  Organism() = delete;
+  Organism(
+      std::shared_ptr<ParametersTable> _PT = nullptr); // make an empty organism
+  // Organism(shared_ptr<AbstractGenome> _genome, shared_ptr<AbstractBrain>
+  // _brain, shared_ptr<ParametersTable> _PT = nullptr);  // make a parentless
+  // organism with a genome, and a brain
+  // Organism(shared_ptr<Organism> from, shared_ptr<AbstractGenome> _genome,
+  // shared_ptr<AbstractBrain> _brain, shared_ptr<ParametersTable> _PT =
+  // nullptr);  // make an organism with one parent, a genome and a brain
+  // determined from the parents brain type.
+  // Organism(const vector<shared_ptr<Organism>> from,
+  // shared_ptr<AbstractGenome> _genome, shared_ptr<AbstractBrain> _brain,
+  // shared_ptr<ParametersTable> _PT = nullptr);  // make a organism with many
+  // parents, a genome, and a brain determined from the parents brain type.
 
+  Organism(
+      std::unordered_map<std::string, std::shared_ptr<AbstractGenome>>
+          &_genomes,
+      std::unordered_map<std::string, std::shared_ptr<AbstractBrain>> &_brains,
+      std::shared_ptr<ParametersTable> _PT =
+          nullptr); // make a parentless organism with a genome, and a brain
+  Organism(
+      std::shared_ptr<Organism> from,
+      std::unordered_map<std::string, std::shared_ptr<AbstractGenome>>
+          &_genomes,
+      std::unordered_map<std::string, std::shared_ptr<AbstractBrain>> &_brains,
+      std::shared_ptr<ParametersTable> _PT = nullptr); // make an organism with
+                                                       // one parent, a genome
+                                                       // and a brain determined
+                                                       // from the parents brain
+                                                       // type.
+  Organism(
+      std::vector<std::shared_ptr<Organism>> from,
+      std::unordered_map<std::string, std::shared_ptr<AbstractGenome>>
+          &_genomes,
+      std::unordered_map<std::string, std::shared_ptr<AbstractBrain>> &_brains,
+      std::shared_ptr<ParametersTable> _PT = nullptr); // make a organism with
+                                                       // many parents, a
+                                                       // genome, and a brain
+                                                       // determined from the
+                                                       // parents brain type.
 
-	Organism(unordered_map<string,shared_ptr<AbstractGenome>>& _genomes, unordered_map<string,shared_ptr<AbstractBrain>>& _brains, shared_ptr<ParametersTable> _PT = nullptr);  // make a parentless organism with a genome, and a brain
-	Organism(shared_ptr<Organism> from, unordered_map<string, shared_ptr<AbstractGenome>>& _genomes, unordered_map<string, shared_ptr<AbstractBrain>>& _brains, shared_ptr<ParametersTable> _PT = nullptr);  // make an organism with one parent, a genome and a brain determined from the parents brain type.
-	Organism(vector<shared_ptr<Organism>> from, unordered_map<string, shared_ptr<AbstractGenome>>& _genomes, unordered_map<string, shared_ptr<AbstractBrain>>& _brains, shared_ptr<ParametersTable> _PT = nullptr);  // make a organism with many parents, a genome, and a brain determined from the parents brain type.
+  virtual ~Organism();
 
+  bool hasGenome() { return genome != nullptr; }
+  bool hasBrain() { return brain != nullptr; }
 
-	virtual ~Organism();
+  virtual void kill(); // sets alive = 0 (on org and in dataMap)
 
-	bool hasGenome() {
-		return genome != nullptr;
-	}
-	bool hasBrain() {
-		return brain != nullptr;
-	}
-
-	virtual void kill();  // sets alive = 0 (on org and in dataMap)
-
-	//virtual vector<string> GetLODItem(string key, shared_ptr<Organism> org);
-	virtual vector<shared_ptr<Organism>> getLOD(shared_ptr<Organism> org);
-	virtual shared_ptr<Organism> getMostRecentCommonAncestor(shared_ptr<Organism> org);
-	virtual shared_ptr<Organism> getMostRecentCommonAncestor(vector<shared_ptr<Organism>> LOD);
-	virtual shared_ptr<Organism> makeMutatedOffspringFrom(shared_ptr<Organism> parent);
-	virtual shared_ptr<Organism> makeMutatedOffspringFromMany(vector<shared_ptr<Organism>> from);
-	virtual shared_ptr<Organism> makeCopy(shared_ptr<ParametersTable> _PT = nullptr);
+  // virtual vector<string> GetLODItem(string key, shared_ptr<Organism> org);
+  virtual std::vector<std::shared_ptr<Organism>>
+  getLOD(std::shared_ptr<Organism> org);
+  virtual std::shared_ptr<Organism>
+  getMostRecentCommonAncestor(std::shared_ptr<Organism> org);
+  virtual std::shared_ptr<Organism>
+  getMostRecentCommonAncestor(std::vector<std::shared_ptr<Organism>> LOD);
+  virtual std::shared_ptr<Organism>
+  makeMutatedOffspringFrom(std::shared_ptr<Organism> parent);
+  virtual std::shared_ptr<Organism>
+  makeMutatedOffspringFromMany(std::vector<std::shared_ptr<Organism>> from);
+  virtual std::shared_ptr<Organism>
+  makeCopy(std::shared_ptr<ParametersTable> _PT = nullptr);
 };
-
 

--- a/World/AbstractWorld.cpp
+++ b/World/AbstractWorld.cpp
@@ -10,13 +10,20 @@
 
 #include "AbstractWorld.h"
 
+/*
 #include <math.h>
 
 #include "../Utilities/Data.h"
 #include "../Utilities/MTree.h"
+*/
 
-shared_ptr<ParameterLink<bool>> AbstractWorld::debugPL = Parameters::register_parameter("WORLD-debug", false, "run world in debug mode (if available)");
+std::shared_ptr<ParameterLink<bool>> AbstractWorld::debugPL =
+    Parameters::register_parameter("WORLD-debug", false,
+                                   "run world in debug mode (if available)");
 
 ////// WORLD-worldType is actually set by Modules.h //////
-shared_ptr<ParameterLink<string>> AbstractWorld::worldTypePL = Parameters::register_parameter("WORLD-worldType", (string) "This_string_is_set_by_modules.h", "This_string_is_set_by_modules.h");
+std::shared_ptr<ParameterLink<std::string>> AbstractWorld::worldTypePL =
+    Parameters::register_parameter("WORLD-worldType",
+                                   (std::string) "This_string_is_set_by_modules.h",
+                                   "This_string_is_set_by_modules.h");
 ////// WORLD-worldType is actually set by Modules.h //////

--- a/World/AbstractWorld.h
+++ b/World/AbstractWorld.h
@@ -19,37 +19,41 @@
 #include "../Utilities/Data.h"
 #include "../Utilities/Parameters.h"
 
-using namespace std;
-
 class AbstractWorld {
 public:
-	static shared_ptr<ParameterLink<bool>> debugPL;
-	static shared_ptr<ParameterLink<string>> worldTypePL;
-	
-	const shared_ptr<ParametersTable> PT;
+  static std::shared_ptr<ParameterLink<bool>> debugPL;
+  static std::shared_ptr<ParameterLink<std::string>> worldTypePL;
 
-	int requiredInputs = 0;
-	int requiredOutputs = 0;
+  const std::shared_ptr<ParametersTable> PT;
 
-	vector<string> popFileColumns;
+  int requiredInputs = 0;
+  int requiredOutputs = 0;
 
-	AbstractWorld(shared_ptr<ParametersTable> _PT) :
-			PT(_PT) {
-	}
-	virtual ~AbstractWorld() = default;
+  std::vector<std::string> popFileColumns;
 
-	virtual unordered_map<string, unordered_set<string>> requiredGroups() = 0;// {
-	//	string groupName = "root::";
-	//	string brainName = "root::";
-	//	return { { groupName,{"B:"+ brainName+","+to_string(requiredInputs)+","+to_string(requiredOutputs)}} }; // default requires a root group and a brain (in root namespace) and no genome 
-	//}
+  AbstractWorld(std::shared_ptr<ParametersTable> _PT) : PT(_PT) {}
+  virtual ~AbstractWorld() = default;
 
-	virtual void evaluate(map<string, shared_ptr<Group>>& groups, int analyze = 0, int visualize = 0, int debug = 0) {
-		cout << "  chosen world does not define evaluate()! Exiting." << endl;
-		exit(1);
-	};
-	virtual void evaluateSolo(shared_ptr<Organism> org, int analyze, int visualize, int debug) {
-		cout << "  chosen world does not define evaluateSolo()! Exiting." << endl;
-		exit(1);
-	};
+  virtual std::unordered_map<std::string, std::unordered_set<std::string>>
+  requiredGroups() = 0; // {
+                        //	string groupName = "root::";
+                        //	string brainName = "root::";
+                        //	return { { groupName,{"B:"+
+  // brainName+","+to_string(requiredInputs)+","+to_string(requiredOutputs)}} };
+  //// default requires a root group and a brain (in root namespace) and no
+  // genome
+  //}
+
+  virtual void evaluate(std::map<std::string, std::shared_ptr<Group>> &groups,
+                        int analyze = 0, int visualize = 0, int debug = 0) {
+    std::cout << "  chosen world does not define evaluate()! Exiting."
+              << std::endl;
+    exit(1);
+  };
+  virtual void evaluateSolo(std::shared_ptr<Organism> org, int analyze,
+                            int visualize, int debug) {
+    std::cout << "  chosen world does not define evaluateSolo()! Exiting."
+              << std::endl;
+    exit(1);
+  };
 };


### PR DESCRIPTION
All Abstract files and mandatory modules no longer make namespace std visible.

All files inheriting from an abstract module can continue to make std visible. These will get phased out slowly, since no other module depends on these leaves.
Note: SimpleOptimizer is also fixed, since it depended on AbstractOptimizer to make std namespace visible.