### PR TITLE
removed instances of UB to comply with N4659(5.10 [lex.name] 3.1)

### DIFF
--- a/Archivist/DefaultArchivist.cpp
+++ b/Archivist/DefaultArchivist.cpp
@@ -73,9 +73,9 @@ std::shared_ptr<ParameterLink<bool>>
             "if true, snapshot organisms files will be written (with all "
             "organisms for entire population)");
 
-DefaultArchivist::DefaultArchivist(std::shared_ptr<ParametersTable> _PT,
+DefaultArchivist::DefaultArchivist(std::shared_ptr<ParametersTable> PT_,
                                    std::string _groupPrefix)
-    : PT(_PT), groupPrefix(_groupPrefix) {
+    : PT(PT_), groupPrefix(_groupPrefix) {
 
   writePopFile = Arch_writePopFilePL->get(PT);
   writeMaxFile = Arch_writeMaxFilePL->get(PT);
@@ -167,9 +167,9 @@ DefaultArchivist::DefaultArchivist(std::shared_ptr<ParametersTable> _PT,
 
 DefaultArchivist::DefaultArchivist(std::vector<std::string> popFileColumns,
                                    std::shared_ptr<Abstract_MTree> _maxFormula,
-                                   std::shared_ptr<ParametersTable> _PT,
+                                   std::shared_ptr<ParametersTable> PT_,
                                    std::string _groupPrefix)
-    : DefaultArchivist(_PT, _groupPrefix) {
+    : DefaultArchivist(PT_, _groupPrefix) {
   convertCSVListToVector(PopFileColumnNames, DefaultPopFileColumns);
   maxFormula = _maxFormula;
   if (DefaultPopFileColumns.size() <= 0) {

--- a/Archivist/DefaultArchivist.h
+++ b/Archivist/DefaultArchivist.h
@@ -90,11 +90,11 @@ public:
 
   const std::shared_ptr<ParametersTable> PT;
 
-  DefaultArchivist(std::shared_ptr<ParametersTable> _PT = nullptr,
+  DefaultArchivist(std::shared_ptr<ParametersTable> PT = nullptr,
                    std::string _groupPrefix = "");
   DefaultArchivist(std::vector<std::string> popFileColumns,
                    std::shared_ptr<Abstract_MTree> _maxFormula = nullptr,
-                   std::shared_ptr<ParametersTable> _PT = nullptr,
+                   std::shared_ptr<ParametersTable> PT = nullptr,
                    std::string _groupPrefix = "");
   virtual ~DefaultArchivist() = default;
 

--- a/Archivist/LODwAPArchivist/LODwAPArchivist.cpp
+++ b/Archivist/LODwAPArchivist/LODwAPArchivist.cpp
@@ -22,8 +22,8 @@ shared_ptr<ParameterLink<string>> LODwAPArchivist::LODwAP_Arch_FilePrefixPL = Pa
 
 
 
-LODwAPArchivist::LODwAPArchivist(vector<string> popFileColumns, shared_ptr<Abstract_MTree> _maxFormula, shared_ptr<ParametersTable> _PT, string _groupPrefix) :
-		DefaultArchivist(popFileColumns, _maxFormula, _PT, _groupPrefix) {
+LODwAPArchivist::LODwAPArchivist(vector<string> popFileColumns, shared_ptr<Abstract_MTree> _maxFormula, shared_ptr<ParametersTable> PT_, string _groupPrefix) :
+		DefaultArchivist(popFileColumns, _maxFormula, PT_, _groupPrefix) {
 
 	pruneInterval = LODwAP_Arch_pruneIntervalPL->get(PT);
 	terminateAfter = LODwAP_Arch_terminateAfterPL->get(PT);

--- a/Archivist/LODwAPArchivist/LODwAPArchivist.h
+++ b/Archivist/LODwAPArchivist/LODwAPArchivist.h
@@ -50,7 +50,7 @@ public:
 	//unordered_map<int, vector<weak_ptr<Organism>>> checkpoints;  // used by SSwD only - this keeps lists of orgs that may be written (if they have living decendents)
 	//// key is Global::nextGenomeWrite or Global::nextDataWrite
 	LODwAPArchivist() = delete;
-	LODwAPArchivist(vector<string> popFileColumns = { }, shared_ptr<Abstract_MTree> _maxFormula = nullptr, shared_ptr<ParametersTable> _PT = nullptr, string _groupPrefix ="");
+	LODwAPArchivist(vector<string> popFileColumns = { }, shared_ptr<Abstract_MTree> _maxFormula = nullptr, shared_ptr<ParametersTable> PT_ = nullptr, string _groupPrefix ="");
 
 	virtual ~LODwAPArchivist() = default;
 

--- a/Archivist/SSwDArchivist/SSwDArchivist.cpp
+++ b/Archivist/SSwDArchivist/SSwDArchivist.cpp
@@ -21,8 +21,8 @@ shared_ptr<ParameterLink<string>> SSwDArchivist::SSwD_Arch_FilePrefixPL = Parame
 shared_ptr<ParameterLink<bool>> SSwDArchivist::SSwD_Arch_writeDataFilesPL = Parameters::register_parameter("ARCHIVIST_SSWD-writeDataFiles", true, "if true, data files will be written");
 shared_ptr<ParameterLink<bool>> SSwDArchivist::SSwD_Arch_writeOrganismFilesPL = Parameters::register_parameter("ARCHIVIST_SSWD-writeOrganismsFiles", true, "if true, genome files will be written");
 
-SSwDArchivist::SSwDArchivist(vector<string> popFileColumns, shared_ptr<Abstract_MTree> _maxFormula, shared_ptr<ParametersTable> _PT, string _groupPrefix) :
-	DefaultArchivist(popFileColumns, _maxFormula, _PT, _groupPrefix) {
+SSwDArchivist::SSwDArchivist(vector<string> popFileColumns, shared_ptr<Abstract_MTree> _maxFormula, shared_ptr<ParametersTable> PT_, string _groupPrefix) :
+	DefaultArchivist(popFileColumns, _maxFormula, PT_, _groupPrefix) {
 
 	dataDelay = SSwD_Arch_dataDelayPL->get(PT);
 	organismDelay = SSwD_Arch_organismDelayPL->get(PT);

--- a/Archivist/SSwDArchivist/SSwDArchivist.h
+++ b/Archivist/SSwDArchivist/SSwDArchivist.h
@@ -52,7 +52,7 @@ class SSwDArchivist : public DefaultArchivist {  // SnapShot with Delay
 	// key is Global::nextGenomeWrite or Global::nextDataWrite
 
 	SSwDArchivist() = delete;
-	SSwDArchivist(vector<string> popFileColumns = {}, shared_ptr<Abstract_MTree> _maxFormula = nullptr, shared_ptr<ParametersTable> _PT = nullptr, string _groupPrefix = "");
+	SSwDArchivist(vector<string> popFileColumns = {}, shared_ptr<Abstract_MTree> _maxFormula = nullptr, shared_ptr<ParametersTable> PT_ = nullptr, string _groupPrefix = "");
 
 	virtual ~SSwDArchivist() = default;
 

--- a/Brain/AbstractBrain.h
+++ b/Brain/AbstractBrain.h
@@ -216,7 +216,7 @@ public:
   //	}
 
   virtual std::shared_ptr<AbstractBrain>
-  makeCopy(std::shared_ptr<ParametersTable> _PT = nullptr) {
+  makeCopy(std::shared_ptr<ParametersTable> PT_ = nullptr) {
     std::cout << "ERROR IN AbstractBrain::makeCopy() - You are using the abstract "
             "copy constructor for brains. You must define your own"
          << std::endl;

--- a/Brain/CGPBrain/CGPBrain.cpp
+++ b/Brain/CGPBrain/CGPBrain.cpp
@@ -26,8 +26,8 @@ shared_ptr<ParameterLink<int>> CGPBrain::codonMaxPL = Parameters::register_param
 
 shared_ptr<ParameterLink<bool>> CGPBrain::readFromOutputsPL = Parameters::register_parameter("BRAIN_CGP-readFromOutputs", true, "if true, previous updates outputs will be available as inputs.");
 
-CGPBrain::CGPBrain(int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> _PT) :
-	AbstractBrain(_nrInNodes, _nrOutNodes, _PT) {
+CGPBrain::CGPBrain(int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> PT_) :
+	AbstractBrain(_nrInNodes, _nrOutNodes, PT_) {
 
 	convertCSVListToVector(availableOperatorsPL->get(PT), availableOperators);
 	//nrHiddenValues = (PT == nullptr) ? hiddenNodesPL->lookup() : PT->lookupInt("BRAIN_CGP-hiddenNodes");
@@ -76,8 +76,8 @@ CGPBrain::CGPBrain(int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> 
 
 }
 
-CGPBrain::CGPBrain(int _nrInNodes, int _nrOutNodes, unordered_map<string, shared_ptr<AbstractGenome>>& _genomes, shared_ptr<ParametersTable> _PT) :
-	CGPBrain(_nrInNodes, _nrOutNodes, _PT) {
+CGPBrain::CGPBrain(int _nrInNodes, int _nrOutNodes, unordered_map<string, shared_ptr<AbstractGenome>>& _genomes, shared_ptr<ParametersTable> PT_) :
+	CGPBrain(_nrInNodes, _nrOutNodes, PT_) {
 
 	brainVectors.resize(nrOutputTotal);
 	auto handler = _genomes[genomeNamePL->get(PT)]->newHandler(_genomes[genomeNamePL->get(PT)]);
@@ -408,12 +408,12 @@ void CGPBrain::initializeGenomes(unordered_map<string, shared_ptr<AbstractGenome
 	_genomes[genomeNamePL->get(PT)]->fillRandom();
 }
 
-shared_ptr<AbstractBrain> CGPBrain::makeCopy(shared_ptr<ParametersTable> _PT)
+shared_ptr<AbstractBrain> CGPBrain::makeCopy(shared_ptr<ParametersTable> PT_)
 {
-	if (_PT == nullptr) {
-		_PT = PT;
+	if (PT_ == nullptr) {
+		PT_ = PT;
 	}
-	auto newBrain = make_shared<CGPBrain>(nrInputValues, nrOutputValues, _PT);
+	auto newBrain = make_shared<CGPBrain>(nrInputValues, nrOutputValues, PT_);
 	newBrain->brainVectors = brainVectors;
 	return newBrain;
 }

--- a/Brain/CGPBrain/CGPBrain.h
+++ b/Brain/CGPBrain/CGPBrain.h
@@ -68,8 +68,8 @@ public:
 
 	CGPBrain() = delete;
 
-	CGPBrain(int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> _PT = nullptr);
-	CGPBrain(int _nrInNodes, int _nrOutNodes, unordered_map<string, shared_ptr<AbstractGenome>>& _genomes, shared_ptr<ParametersTable> _PT = nullptr);
+	CGPBrain(int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> PT_ = nullptr);
+	CGPBrain(int _nrInNodes, int _nrOutNodes, unordered_map<string, shared_ptr<AbstractGenome>>& _genomes, shared_ptr<ParametersTable> PT_ = nullptr);
 
 	virtual ~CGPBrain() = default;
 
@@ -93,7 +93,7 @@ public:
 
 	virtual void resetBrain() override;
 
-	virtual shared_ptr<AbstractBrain> makeCopy(shared_ptr<ParametersTable> _PT = nullptr) override;
+	virtual shared_ptr<AbstractBrain> makeCopy(shared_ptr<ParametersTable> PT_ = nullptr) override;
 	virtual void initializeGenomes(unordered_map<string, shared_ptr<AbstractGenome>>& _genomes);
 
 };

--- a/Brain/ConstantValuesBrain/ConstantValuesBrain.cpp
+++ b/Brain/ConstantValuesBrain/ConstantValuesBrain.cpp
@@ -21,8 +21,8 @@ shared_ptr<ParameterLink<double>> ConstantValuesBrain::initializeConstantValuePL
 
 shared_ptr<ParameterLink<string>> ConstantValuesBrain::genomeNamePL = Parameters::register_parameter("BRAIN_CONSTANT_NAMES-genomeNameSpace", (string)"root::", "namespace used to set parameters for genome used to encode this brain");
 
-ConstantValuesBrain::ConstantValuesBrain(int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> _PT) :
-		AbstractBrain(_nrInNodes, _nrOutNodes, _PT) {
+ConstantValuesBrain::ConstantValuesBrain(int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> PT_) :
+		AbstractBrain(_nrInNodes, _nrOutNodes, PT_) {
 
 // columns to be added to ave file
 	popFileColumns.clear();
@@ -148,12 +148,12 @@ void ConstantValuesBrain::initializeGenomes(unordered_map<string, shared_ptr<Abs
 	}
 }
 
-shared_ptr<AbstractBrain> ConstantValuesBrain::makeCopy(shared_ptr<ParametersTable> _PT)
+shared_ptr<AbstractBrain> ConstantValuesBrain::makeCopy(shared_ptr<ParametersTable> PT_)
 {
-	if (_PT == nullptr) {
-		_PT = PT;
+	if (PT_ == nullptr) {
+		PT_ = PT;
 	}
-	auto newBrain = make_shared<ConstantValuesBrain>(nrInputValues, nrOutputValues, _PT);
+	auto newBrain = make_shared<ConstantValuesBrain>(nrInputValues, nrOutputValues, PT_);
 
 	for (int i = 0; i < nrOutputValues; i++) {
 		newBrain->outputValues[i] = outputValues[i];

--- a/Brain/ConstantValuesBrain/ConstantValuesBrain.h
+++ b/Brain/ConstantValuesBrain/ConstantValuesBrain.h
@@ -41,7 +41,7 @@ public:
 
 	ConstantValuesBrain() = delete;
 
-	ConstantValuesBrain(int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> _PT = nullptr);
+	ConstantValuesBrain(int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> PT_ = nullptr);
 
 	virtual ~ConstantValuesBrain() = default;
 
@@ -62,7 +62,7 @@ public:
 	virtual void resetBrain() override;
 	virtual void resetOutputs() override;
 
-	virtual shared_ptr<AbstractBrain> makeCopy(shared_ptr<ParametersTable> _PT = nullptr) override;
+	virtual shared_ptr<AbstractBrain> makeCopy(shared_ptr<ParametersTable> PT_ = nullptr) override;
 
 	virtual void initializeGenomes(unordered_map<string, shared_ptr<AbstractGenome>>& _genomes);
 };

--- a/Brain/HumanBrain/HumanBrain.cpp
+++ b/Brain/HumanBrain/HumanBrain.cpp
@@ -13,8 +13,8 @@
 shared_ptr<ParameterLink<bool>> HumanBrain::useActionMapPL = Parameters::register_parameter("BRAIN_HUMAN-useActionMap", false, "if true, an action map will be used to translate user input");
 shared_ptr<ParameterLink<string>> HumanBrain::actionMapFileNamePL = Parameters::register_parameter("BRAIN_HUMAN-actionMapFileName", (string) "actionMap.txt", "if useActionMap = true, use this file");
 
-HumanBrain::HumanBrain(int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> _PT) :
-		AbstractBrain(_nrInNodes, _nrOutNodes, _PT) {
+HumanBrain::HumanBrain(int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> PT_) :
+		AbstractBrain(_nrInNodes, _nrOutNodes, PT_) {
 	useActionMap = useActionMapPL->get(PT);
 	actionMapFileName = actionMapFileNamePL->get(PT);
 
@@ -118,12 +118,12 @@ void HumanBrain::initializeGenomes(unordered_map<string, shared_ptr<AbstractGeno
 // do nothing;
 }
 
-shared_ptr<AbstractBrain> HumanBrain::makeCopy(shared_ptr<ParametersTable> _PT)
+shared_ptr<AbstractBrain> HumanBrain::makeCopy(shared_ptr<ParametersTable> PT_)
 {
-	if (_PT == nullptr) {
-		_PT = PT;
+	if (PT_ == nullptr) {
+		PT_ = PT;
 	}
-	auto newBrain = make_shared<HumanBrain>(nrInputValues, nrOutputValues, _PT);
+	auto newBrain = make_shared<HumanBrain>(nrInputValues, nrOutputValues, PT_);
 	return newBrain;
 }
 

--- a/Brain/HumanBrain/HumanBrain.h
+++ b/Brain/HumanBrain/HumanBrain.h
@@ -45,7 +45,7 @@ public:
 	virtual void update() override;
 
 	virtual shared_ptr<AbstractBrain> makeBrain(unordered_map<string, shared_ptr<AbstractGenome>>& _genomes) override;
-	virtual shared_ptr<AbstractBrain> makeCopy(shared_ptr<ParametersTable> _PT = nullptr) override;
+	virtual shared_ptr<AbstractBrain> makeCopy(shared_ptr<ParametersTable> PT_ = nullptr) override;
 
 	//virtual shared_ptr<AbstractBrain> makeMutatedBrainFrom(shared_ptr<AbstractBrain> parent) override {
 	//	//cout << "  in makeMutatedBrainFrom" << endl;

--- a/Brain/LSTMBrain/LSTMBrain.h
+++ b/Brain/LSTMBrain/LSTMBrain.h
@@ -35,13 +35,13 @@ public:
     vector<vector<double>> Wf,Wi,Wc,Wo;
     vector<double> ft,it,Ct,Ot,dt;
     vector<double> bt,bi,bC,bO;
-    int _I,_O;
+    int I_,O_;
     vector<double> C,X,H;
 
     
 	LSTMBrain() = delete;
 
-	LSTMBrain(int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> _PT);
+	LSTMBrain(int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> PT_);
 
 	virtual ~LSTMBrain() = default;
 

--- a/Brain/MarkovBrain/MarkovBrain.cpp
+++ b/Brain/MarkovBrain/MarkovBrain.cpp
@@ -31,8 +31,8 @@ void MarkovBrain::readParameters(){
 	nextNodes.resize(nrNodes, 0);
 }
 
-MarkovBrain::MarkovBrain(vector<shared_ptr<AbstractGate>> _gates, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> _PT) :
-		AbstractBrain(_nrInNodes, _nrOutNodes, _PT) {
+MarkovBrain::MarkovBrain(vector<shared_ptr<AbstractGate>> _gates, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> PT_) :
+		AbstractBrain(_nrInNodes, _nrOutNodes, PT_) {
 
 	readParameters();
 
@@ -49,9 +49,9 @@ MarkovBrain::MarkovBrain(vector<shared_ptr<AbstractGate>> _gates, int _nrInNodes
 	fillInConnectionsLists();
 }
 
-MarkovBrain::MarkovBrain(shared_ptr<AbstractGateListBuilder> _GLB, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> _PT) :
-		AbstractBrain(_nrInNodes, _nrOutNodes, _PT) {
-	GLB = _GLB;
+MarkovBrain::MarkovBrain(shared_ptr<AbstractGateListBuilder> GLB_, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> PT_) :
+		AbstractBrain(_nrInNodes, _nrOutNodes, PT_) {
+	GLB = GLB_;
 	//make a node map to handle genome value to brain state address look up.
 
 	readParameters();
@@ -69,10 +69,10 @@ MarkovBrain::MarkovBrain(shared_ptr<AbstractGateListBuilder> _GLB, int _nrInNode
 	fillInConnectionsLists();
 }
 
-MarkovBrain::MarkovBrain(shared_ptr<AbstractGateListBuilder> _GLB, unordered_map<string, shared_ptr<AbstractGenome>>& _genomes, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> _PT) :
-		MarkovBrain(_GLB, _nrInNodes, _nrOutNodes, _PT) {
-	//cout << "in MarkovBrain::MarkovBrain(shared_ptr<Base_GateListBuilder> _GLB, shared_ptr<AbstractGenome> genome, int _nrOfBrainStates)\n\tabout to - gates = GLB->buildGateList(genome, nrOfBrainStates);" << endl;
-	gates = GLB->buildGateList(_genomes[genomeName], nrNodes, _PT);
+MarkovBrain::MarkovBrain(shared_ptr<AbstractGateListBuilder> GLB_, unordered_map<string, shared_ptr<AbstractGenome>>& _genomes, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> PT_) :
+		MarkovBrain(GLB_, _nrInNodes, _nrOutNodes, PT_) {
+	//cout << "in MarkovBrain::MarkovBrain(shared_ptr<Base_GateListBuilder> GLB_, shared_ptr<AbstractGenome> genome, int _nrOfBrainStates)\n\tabout to - gates = GLB->buildGateList(genome, nrOfBrainStates);" << endl;
+	gates = GLB->buildGateList(_genomes[genomeName], nrNodes, PT_);
 	inOutReMap();  // map ins and outs from genome values to brain states
 	fillInConnectionsLists();
 }
@@ -250,15 +250,15 @@ void MarkovBrain::initializeGenomes(unordered_map<string, shared_ptr<AbstractGen
 	}
 }
 
-shared_ptr<AbstractBrain> MarkovBrain::makeCopy(shared_ptr<ParametersTable> _PT)
+shared_ptr<AbstractBrain> MarkovBrain::makeCopy(shared_ptr<ParametersTable> PT_)
 {
-	if (_PT == nullptr) {
-		_PT = PT;
+	if (PT_ == nullptr) {
+		PT_ = PT;
 	}
 	vector<shared_ptr<AbstractGate>> _gates; 
 	for (auto gate : gates) {
 		_gates.push_back(gate->makeCopy());
 	}
-	auto newBrain = make_shared<MarkovBrain>(_gates, nrInputValues, nrOutputValues, _PT);
+	auto newBrain = make_shared<MarkovBrain>(_gates, nrInputValues, nrOutputValues, PT_);
 	return newBrain;
 }

--- a/Brain/MarkovBrain/MarkovBrain.h
+++ b/Brain/MarkovBrain/MarkovBrain.h
@@ -75,13 +75,13 @@ class MarkovBrain : public AbstractBrain {
 
 	MarkovBrain() = delete;
 
-	MarkovBrain(vector<shared_ptr<AbstractGate>> _gates, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> _PT = nullptr);
-	MarkovBrain(shared_ptr<AbstractGateListBuilder> _GLB, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> _PT = nullptr);
-	MarkovBrain(shared_ptr<AbstractGateListBuilder> _GLB, unordered_map<string, shared_ptr<AbstractGenome>>& _genomes, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> _PT = nullptr);
+	MarkovBrain(vector<shared_ptr<AbstractGate>> _gates, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> PT_ = nullptr);
+	MarkovBrain(shared_ptr<AbstractGateListBuilder> GLB_, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> PT_ = nullptr);
+	MarkovBrain(shared_ptr<AbstractGateListBuilder> GLB_, unordered_map<string, shared_ptr<AbstractGenome>>& _genomes, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> PT_ = nullptr);
 
 	virtual ~MarkovBrain() = default;
 
-	virtual shared_ptr<AbstractBrain> makeCopy(shared_ptr<ParametersTable> _PT = nullptr) override;
+	virtual shared_ptr<AbstractBrain> makeCopy(shared_ptr<ParametersTable> PT_ = nullptr) override;
 
 	void readParameters();
 

--- a/Brain/WireBrain/WireBrain.cpp
+++ b/Brain/WireBrain/WireBrain.cpp
@@ -44,8 +44,8 @@ shared_ptr<ParameterLink<int>> WireBrain::bitsPerCodonPL = Parameters::register_
 
 shared_ptr<ParameterLink<string>> WireBrain::genomeNamePL = Parameters::register_parameter("BRAIN_WIRE_NAMES-genomeNameSpace", (string)"root::", "namespace used to set parameters for genome used to encode this brain");
 
-WireBrain::WireBrain(int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> _PT) :
-		AbstractBrain(_nrInNodes, _nrOutNodes,  _PT) {
+WireBrain::WireBrain(int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> PT_) :
+		AbstractBrain(_nrInNodes, _nrOutNodes,  PT_) {
 
 	allowNegativeCharge = allowNegativeChargePL->get(PT);
 	defaultWidth = defaultWidthPL->get(PT);
@@ -97,8 +97,8 @@ WireBrain::WireBrain(int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable
 	popFileColumns.push_back("wireBrainConnectionsCount");
 }
 
-WireBrain::WireBrain(const vector<bool> &genome, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> _PT) :
-		WireBrain(_nrInNodes, _nrOutNodes, _PT) {
+WireBrain::WireBrain(const vector<bool> &genome, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> PT_) :
+		WireBrain(_nrInNodes, _nrOutNodes, PT_) {
 	initialize();
 
 	if ((int) genome.size() < width * depth * height) {
@@ -118,8 +118,8 @@ WireBrain::WireBrain(const vector<bool> &genome, int _nrInNodes, int _nrOutNodes
 	popFileColumns.push_back("wireBrainConnectionsCount");
 }
 
-WireBrain::WireBrain(unordered_map<string, shared_ptr<AbstractGenome>>& _genomes, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> _PT) :
-		WireBrain(_nrInNodes, _nrOutNodes, _PT) {
+WireBrain::WireBrain(unordered_map<string, shared_ptr<AbstractGenome>>& _genomes, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> PT_) :
+		WireBrain(_nrInNodes, _nrOutNodes, PT_) {
 	//cout << "in WireBrain(shared_ptr<AbstractGenome> genome, int _nrOfNodes)" << endl;
 	initialize();
 
@@ -1161,12 +1161,12 @@ void WireBrain::initializeGenomes(unordered_map<string, shared_ptr<AbstractGenom
 	}
 }
 
-shared_ptr<AbstractBrain> WireBrain::makeCopy(shared_ptr<ParametersTable> _PT)
+shared_ptr<AbstractBrain> WireBrain::makeCopy(shared_ptr<ParametersTable> PT_)
 {
-	if (_PT == nullptr) {
-		_PT = PT;
+	if (PT_ == nullptr) {
+		PT_ = PT;
 	}
-	auto newBrain = make_shared<WireBrain>(nrInputValues, nrOutputValues, _PT);
+	auto newBrain = make_shared<WireBrain>(nrInputValues, nrOutputValues, PT_);
 
 	newBrain->allCells = allCells;
 	newBrain->wireAddresses = wireAddresses;

--- a/Brain/WireBrain/WireBrain.h
+++ b/Brain/WireBrain/WireBrain.h
@@ -125,15 +125,15 @@ public:
 
 	int nrValues;
 
-	WireBrain(int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> _PT = nullptr);
-	WireBrain(unordered_map<string, shared_ptr<AbstractGenome>>& _genomes, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> _PT = nullptr);
-	WireBrain(const vector<bool> &genome, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> _PT = nullptr);
+	WireBrain(int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> PT_ = nullptr);
+	WireBrain(unordered_map<string, shared_ptr<AbstractGenome>>& _genomes, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> PT_ = nullptr);
+	WireBrain(const vector<bool> &genome, int _nrInNodes, int _nrOutNodes, shared_ptr<ParametersTable> PT_ = nullptr);
 	virtual ~WireBrain() = default;
 
 	virtual void initialize();
 	virtual void connectPruneAndSetPopColumns(vector<pair<int, int>> wormholeList);
 	virtual shared_ptr<AbstractBrain> makeBrain(unordered_map<string, shared_ptr<AbstractGenome>>& _genomes) override;
-	virtual shared_ptr<AbstractBrain> makeCopy(shared_ptr<ParametersTable> _PT = nullptr) override;
+	virtual shared_ptr<AbstractBrain> makeCopy(shared_ptr<ParametersTable> PT_ = nullptr) override;
 
 	virtual void chargeUpdate();
 	virtual void chargeUpdateTrit();

--- a/Genome/AbstractGenome.h
+++ b/Genome/AbstractGenome.h
@@ -133,14 +133,14 @@ public:
   std::vector<std::string> popFileColumns; // = {"genomeLength"};
 
   AbstractGenome() = delete;
-  AbstractGenome(std::shared_ptr<ParametersTable> _PT) : PT(_PT) {}
+  AbstractGenome(std::shared_ptr<ParametersTable> PT_) : PT(PT_) {}
 
   virtual ~AbstractGenome() = default;
   // virtual shared_ptr<AbstractGenome::Handler>
   // newHandler(shared_ptr<AbstractGenome> _genome, bool _readDirection = true)
   // override {
 
-  virtual std::shared_ptr<AbstractGenome> makeCopy(std::shared_ptr<ParametersTable> _PT) {
+  virtual std::shared_ptr<AbstractGenome> makeCopy(std::shared_ptr<ParametersTable> PT_) {
     std::cout << "ERROR IN AbstractGenome::makeCopy() - You are using the abstract "
             "copy constructor for genomes. You must define your own"
          << std::endl;

--- a/Genome/CircularGenome/CircularGenome.cpp
+++ b/Genome/CircularGenome/CircularGenome.cpp
@@ -334,23 +334,23 @@ void CircularGenome<T>::setupCircularGenome(int _size, double _alphabetSize) {
 }
 
 //template<class T>
-//CircularGenome<T>::CircularGenome(double _alphabetSize, int _size, shared_ptr<ParametersTable> _PT) : AbstractGenome(_PT){
+//CircularGenome<T>::CircularGenome(double _alphabetSize, int _size, shared_ptr<ParametersTable> PT_) : AbstractGenome(PT_){
 //	setupCircularGenome(_size, _alphabetSize);
 //}
 
 template<class T>
-CircularGenome<T>::CircularGenome(double _alphabetSize, int _size, shared_ptr<ParametersTable> _PT) : AbstractGenome(_PT) {
+CircularGenome<T>::CircularGenome(double _alphabetSize, int _size, shared_ptr<ParametersTable> PT_) : AbstractGenome(PT_) {
 	setupCircularGenome(_size, _alphabetSize);
 	cout << "ERROR : TYPE specified for CircularGenome is not supported.\nTypes supported are: int, double, bool, unsigned char" << endl;
 	exit(1);
 }
 
 template<>
-CircularGenome<int>::CircularGenome(double _alphabetSize, int _size, shared_ptr<ParametersTable> _PT) : AbstractGenome(_PT) {
+CircularGenome<int>::CircularGenome(double _alphabetSize, int _size, shared_ptr<ParametersTable> PT_) : AbstractGenome(PT_) {
 	setupCircularGenome(_size, _alphabetSize);
 }
 template<>
-CircularGenome<bool>::CircularGenome(double _alphabetSize, int _size, shared_ptr<ParametersTable> _PT) : AbstractGenome(_PT) {
+CircularGenome<bool>::CircularGenome(double _alphabetSize, int _size, shared_ptr<ParametersTable> PT_) : AbstractGenome(PT_) {
 	if (_alphabetSize != 2) {
 		cout << "ERROR: in CircularGenome constructor, alphabetSize for bool must be 2!" << endl;
 		exit(1);
@@ -358,11 +358,11 @@ CircularGenome<bool>::CircularGenome(double _alphabetSize, int _size, shared_ptr
 	setupCircularGenome(_size, _alphabetSize);
 }
 template<>
-CircularGenome<double>::CircularGenome(double _alphabetSize, int _size, shared_ptr<ParametersTable> _PT) : AbstractGenome(_PT) {
+CircularGenome<double>::CircularGenome(double _alphabetSize, int _size, shared_ptr<ParametersTable> PT_) : AbstractGenome(PT_) {
 	setupCircularGenome(_size, _alphabetSize);
 }
 template<>
-CircularGenome<unsigned char>::CircularGenome(double _alphabetSize, int _size, shared_ptr<ParametersTable> _PT) : AbstractGenome(_PT) {
+CircularGenome<unsigned char>::CircularGenome(double _alphabetSize, int _size, shared_ptr<ParametersTable> PT_) : AbstractGenome(PT_) {
 	if (_alphabetSize > 256 || _alphabetSize < 2) {
 		cout << "ERROR: in CircularGenome constructor, alphabetSize for unsigned char must be 2 or greater and 256 or less!" << endl;
 		exit(1);
@@ -371,12 +371,12 @@ CircularGenome<unsigned char>::CircularGenome(double _alphabetSize, int _size, s
 }
 
 template<class T>
-shared_ptr<AbstractGenome> CircularGenome<T>::makeCopy(shared_ptr<ParametersTable> _PT) {
-	if (_PT == nullptr) {
-		_PT = PT;
+shared_ptr<AbstractGenome> CircularGenome<T>::makeCopy(shared_ptr<ParametersTable> PT_) {
+	if (PT_ == nullptr) {
+		PT_ = PT;
 	}
 
-	auto newGenome = make_shared<CircularGenome>(alphabetSize, 1, _PT);
+	auto newGenome = make_shared<CircularGenome>(alphabetSize, 1, PT_);
 	newGenome->sites = sites; 
 
 	return newGenome;

--- a/Genome/CircularGenome/CircularGenome.h
+++ b/Genome/CircularGenome/CircularGenome.h
@@ -119,17 +119,17 @@ public:
 
 	CircularGenome() = delete;
 
-	CircularGenome(shared_ptr<ParametersTable> _PT) : AbstractGenome(_PT){
+	CircularGenome(shared_ptr<ParametersTable> PT_) : AbstractGenome(PT_){
 		setupCircularGenome(256, 100);
 	}
 
-//	CircularGenome(double _alphabetSize, shared_ptr<ParametersTable> _PT) : AbstractGenome(_PT){
+//	CircularGenome(double _alphabetSize, shared_ptr<ParametersTable> PT_) : AbstractGenome(PT_){
 //		alphabetSize = _alphabetSize;
 //	}
 
-	CircularGenome(double _alphabetSize, int _size, shared_ptr<ParametersTable> _PT);
+	CircularGenome(double _alphabetSize, int _size, shared_ptr<ParametersTable> PT_);
 
-	virtual shared_ptr<AbstractGenome> makeCopy(shared_ptr<ParametersTable> _PT);
+	virtual shared_ptr<AbstractGenome> makeCopy(shared_ptr<ParametersTable> PT_);
 	
 	virtual ~CircularGenome() = default;
 

--- a/Genome/MultiGenome/MultiGenome.cpp
+++ b/Genome/MultiGenome/MultiGenome.cpp
@@ -266,7 +266,7 @@ vector<vector<int>> MultiGenome::Handler::readTable(pair<int, int> tableSize, pa
 }
 
 // make an empty genome and ploidy = 1
-MultiGenome::MultiGenome(shared_ptr<ParametersTable> _PT) : AbstractGenome(_PT){
+MultiGenome::MultiGenome(shared_ptr<ParametersTable> PT_) : AbstractGenome(PT_){
 
 	//initialPloidyLPL = (PT == nullptr) ? initialGenomeSizePL : Parameters::getIntLink("GENOME_CIRCULAR-sizeInitial", PT);;
 	//initialChromosomesLPL = ;
@@ -299,8 +299,8 @@ MultiGenome::MultiGenome(shared_ptr<ParametersTable> _PT) : AbstractGenome(_PT){
 }
 
 // make a genome with 1 chromosome
-MultiGenome::MultiGenome(shared_ptr<AbstractChromosome> _chromosome, shared_ptr<ParametersTable> _PT) :
-		MultiGenome(_PT) {
+MultiGenome::MultiGenome(shared_ptr<AbstractChromosome> _chromosome, shared_ptr<ParametersTable> PT_) :
+		MultiGenome(PT_) {
 	//ploidy = 1;
 	chromosomes.push_back(_chromosome->makeLike());
 	/////////chromosomes[0]->fillRandom();  // resize and set with random values
@@ -308,8 +308,8 @@ MultiGenome::MultiGenome(shared_ptr<AbstractChromosome> _chromosome, shared_ptr<
 }
 
 // make a genome with 1 or more chromosome and ploidy >= 1
-MultiGenome::MultiGenome(shared_ptr<AbstractChromosome> _chromosome, int chromosomeCount, int _ploidy, shared_ptr<ParametersTable> _PT) :
-		MultiGenome(_PT) {
+MultiGenome::MultiGenome(shared_ptr<AbstractChromosome> _chromosome, int chromosomeCount, int _ploidy, shared_ptr<ParametersTable> PT_) :
+		MultiGenome(PT_) {
 	ploidy = _ploidy;
 	if (ploidy < 1) {
 		cout << "Error: Genome must have plodiy >= 1";
@@ -325,8 +325,8 @@ MultiGenome::MultiGenome(shared_ptr<AbstractChromosome> _chromosome, int chromos
 	recordDataMap();
 }
 
-shared_ptr<AbstractGenome> MultiGenome::makeCopy(shared_ptr<ParametersTable> _PT) {
-	auto newGenome = make_shared<MultiGenome>(_PT);
+shared_ptr<AbstractGenome> MultiGenome::makeCopy(shared_ptr<ParametersTable> PT_) {
+	auto newGenome = make_shared<MultiGenome>(PT_);
 	newGenome->chromosomes.resize(0);
 	for (auto chromosome : chromosomes) {
 		newGenome->chromosomes.push_back(chromosome->makeCopy());

--- a/Genome/MultiGenome/MultiGenome.h
+++ b/Genome/MultiGenome/MultiGenome.h
@@ -120,10 +120,10 @@ public:
 	vector<shared_ptr<AbstractChromosome>> chromosomes;
 
 	MultiGenome() = delete;
-	MultiGenome(shared_ptr<ParametersTable> _PT);
-	MultiGenome(shared_ptr<AbstractChromosome> _chromosome, shared_ptr<ParametersTable> _PT);
-	MultiGenome(shared_ptr<AbstractChromosome> _chromosome, int chromosomeCount, int _plodiy, shared_ptr<ParametersTable> _PT);
-	virtual shared_ptr<AbstractGenome> makeCopy(shared_ptr<ParametersTable> _PT) override;
+	MultiGenome(shared_ptr<ParametersTable> PT_);
+	MultiGenome(shared_ptr<AbstractChromosome> _chromosome, shared_ptr<ParametersTable> PT_);
+	MultiGenome(shared_ptr<AbstractChromosome> _chromosome, int chromosomeCount, int _plodiy, shared_ptr<ParametersTable> PT_);
+	virtual shared_ptr<AbstractGenome> makeCopy(shared_ptr<ParametersTable> PT_) override;
 	virtual ~MultiGenome() = default;
 
 	virtual shared_ptr<AbstractGenome> makeLike() override {

--- a/Optimizer/AbstractOptimizer.h
+++ b/Optimizer/AbstractOptimizer.h
@@ -36,7 +36,7 @@ public:
   std::unordered_set<std::shared_ptr<Organism>>
       killList; // set of organisms to be killed after archive
 
-  AbstractOptimizer(std::shared_ptr<ParametersTable> _PT) : PT(_PT) {}
+  AbstractOptimizer(std::shared_ptr<ParametersTable> PT_) : PT(PT_) {}
 
   virtual ~AbstractOptimizer() = default;
   // virtual vector<shared_ptr<Organism>>

--- a/Optimizer/SimpleOptimizer/SimpleOptimizer.cpp
+++ b/Optimizer/SimpleOptimizer/SimpleOptimizer.cpp
@@ -51,8 +51,8 @@ std::shared_ptr<ParameterLink<std::string>> SimpleOptimizer::nextPopSizePL =
         "size of population after optimization(MTree). -1 indicates use "
         "current population size");
 
-SimpleOptimizer::SimpleOptimizer(std::shared_ptr<ParametersTable> _PT)
-    : AbstractOptimizer(_PT) {
+SimpleOptimizer::SimpleOptimizer(std::shared_ptr<ParametersTable> PT_)
+    : AbstractOptimizer(PT_) {
 
   selectionMethod = selectionMethodPL->get(PT);
   numberParents = numberParentsPL->get(PT);

--- a/Optimizer/SimpleOptimizer/SimpleOptimizer.h
+++ b/Optimizer/SimpleOptimizer/SimpleOptimizer.h
@@ -65,15 +65,15 @@ public:
   public:
     SimpleOptimizer *SO;
     AbstractSelector() = default;
-    AbstractSelector(SimpleOptimizer *_SO) : SO(_SO){};
+    AbstractSelector(SimpleOptimizer *SO_) : SO(SO_){};
     virtual int select() = 0;
     virtual std::string getType() = 0;
   };
 
   class RouletteSelector : public AbstractSelector {
   public:
-    RouletteSelector(std::string &argumentsString, SimpleOptimizer *_SO)
-        : AbstractSelector(_SO) {
+    RouletteSelector(std::string &argumentsString, SimpleOptimizer *SO_)
+        : AbstractSelector(SO_) {
       // now decode arguments
       std::vector<std::string> arguments;
       std::stringstream ss(argumentsString); // Turn the string into a stream.
@@ -109,8 +109,8 @@ public:
   class TournamentSelector : public AbstractSelector {
   public:
     int tournamentSize;
-    TournamentSelector(std::string &argumentsString, SimpleOptimizer *_SO)
-        : AbstractSelector(_SO) {
+    TournamentSelector(std::string &argumentsString, SimpleOptimizer *SO_)
+        : AbstractSelector(SO_) {
       // now decode arguments
       std::vector<std::string> arguments;
       std::stringstream ss(argumentsString); // Turn the string into a stream.

--- a/Organism/Organism.cpp
+++ b/Organism/Organism.cpp
@@ -26,8 +26,8 @@ int Organism::organismIDCounter = -1; // every organism will get a unique ID
 
 // this is used to hold the most recent common ancestor
 
-void Organism::initOrganism(std::shared_ptr<ParametersTable> _PT) {
-  PT = _PT;
+void Organism::initOrganism(std::shared_ptr<ParametersTable> PT_) {
+  PT = PT_;
   ID = registerOrganism();
   alive = true;
   offspringCount = 0;           // because it's alive;
@@ -42,8 +42,8 @@ void Organism::initOrganism(std::shared_ptr<ParametersTable> _PT) {
  * create an empty organism - it must be filled somewhere else.
  * parents is left empty (this is organism has no parents!)
  */
-Organism::Organism(std::shared_ptr<ParametersTable> _PT) {
-  initOrganism(_PT);
+Organism::Organism(std::shared_ptr<ParametersTable> PT_) {
+  initOrganism(PT_);
   ancestors.insert(ID); // it is it's own Ancestor for data tracking purposes
   snapshotAncestors.insert(ID);
 }
@@ -59,8 +59,8 @@ Organism::Organism(std::shared_ptr<ParametersTable> _PT) {
 Organism::Organism(
     std::unordered_map<std::string, std::shared_ptr<AbstractGenome>> &_genomes,
     std::unordered_map<std::string, std::shared_ptr<AbstractBrain>> &_brains,
-    std::shared_ptr<ParametersTable> _PT) {
-  initOrganism(_PT);
+    std::shared_ptr<ParametersTable> PT_) {
+  initOrganism(PT_);
 
   genomes = _genomes;
 
@@ -104,8 +104,8 @@ Organism::Organism(
     std::shared_ptr<Organism> from,
     std::unordered_map<std::string, std::shared_ptr<AbstractGenome>> &_genomes,
     std::unordered_map<std::string, std::shared_ptr<AbstractBrain>> &_brains,
-    std::shared_ptr<ParametersTable> _PT) {
-  initOrganism(_PT);
+    std::shared_ptr<ParametersTable> PT_) {
+  initOrganism(PT_);
 
   genomes = _genomes;
 
@@ -157,8 +157,8 @@ Organism::Organism(
     std::vector<std::shared_ptr<Organism>> from,
     std::unordered_map<std::string, std::shared_ptr<AbstractGenome>> &_genomes,
     std::unordered_map<std::string, std::shared_ptr<AbstractBrain>> &_brains,
-    std::shared_ptr<ParametersTable> _PT) {
-  initOrganism(_PT);
+    std::shared_ptr<ParametersTable> PT_) {
+  initOrganism(PT_);
 
   genomes = _genomes;
 
@@ -352,8 +352,8 @@ std::shared_ptr<Organism> Organism::getMostRecentCommonAncestor(
 }
 
 std::shared_ptr<Organism>
-Organism::makeCopy(std::shared_ptr<ParametersTable> _PT) {
-  auto newOrg = std::make_shared<Organism>(_PT);
+Organism::makeCopy(std::shared_ptr<ParametersTable> PT_) {
+  auto newOrg = std::make_shared<Organism>(PT_);
   for (auto genome : genomes) {
     newOrg->genomes[genome.first] = genome.second->makeCopy(genome.second->PT);
   }

--- a/Organism/Organism.h
+++ b/Organism/Organism.h
@@ -65,35 +65,35 @@ public:
   bool trackOrganism =
       false; // if false, genome will be deleted when organism dies.
 
-  void initOrganism(std::shared_ptr<ParametersTable> _PT);
+  void initOrganism(std::shared_ptr<ParametersTable> PT_);
 
   Organism() = delete;
   Organism(
-      std::shared_ptr<ParametersTable> _PT = nullptr); // make an empty organism
+      std::shared_ptr<ParametersTable> PT_ = nullptr); // make an empty organism
   // Organism(shared_ptr<AbstractGenome> _genome, shared_ptr<AbstractBrain>
-  // _brain, shared_ptr<ParametersTable> _PT = nullptr);  // make a parentless
+  // _brain, shared_ptr<ParametersTable> PT_ = nullptr);  // make a parentless
   // organism with a genome, and a brain
   // Organism(shared_ptr<Organism> from, shared_ptr<AbstractGenome> _genome,
-  // shared_ptr<AbstractBrain> _brain, shared_ptr<ParametersTable> _PT =
+  // shared_ptr<AbstractBrain> _brain, shared_ptr<ParametersTable> PT_ =
   // nullptr);  // make an organism with one parent, a genome and a brain
   // determined from the parents brain type.
   // Organism(const vector<shared_ptr<Organism>> from,
   // shared_ptr<AbstractGenome> _genome, shared_ptr<AbstractBrain> _brain,
-  // shared_ptr<ParametersTable> _PT = nullptr);  // make a organism with many
+  // shared_ptr<ParametersTable> PT_ = nullptr);  // make a organism with many
   // parents, a genome, and a brain determined from the parents brain type.
 
   Organism(
       std::unordered_map<std::string, std::shared_ptr<AbstractGenome>>
           &_genomes,
       std::unordered_map<std::string, std::shared_ptr<AbstractBrain>> &_brains,
-      std::shared_ptr<ParametersTable> _PT =
+      std::shared_ptr<ParametersTable> PT_ =
           nullptr); // make a parentless organism with a genome, and a brain
   Organism(
       std::shared_ptr<Organism> from,
       std::unordered_map<std::string, std::shared_ptr<AbstractGenome>>
           &_genomes,
       std::unordered_map<std::string, std::shared_ptr<AbstractBrain>> &_brains,
-      std::shared_ptr<ParametersTable> _PT = nullptr); // make an organism with
+      std::shared_ptr<ParametersTable> PT_ = nullptr); // make an organism with
                                                        // one parent, a genome
                                                        // and a brain determined
                                                        // from the parents brain
@@ -103,7 +103,7 @@ public:
       std::unordered_map<std::string, std::shared_ptr<AbstractGenome>>
           &_genomes,
       std::unordered_map<std::string, std::shared_ptr<AbstractBrain>> &_brains,
-      std::shared_ptr<ParametersTable> _PT = nullptr); // make a organism with
+      std::shared_ptr<ParametersTable> PT_ = nullptr); // make a organism with
                                                        // many parents, a
                                                        // genome, and a brain
                                                        // determined from the
@@ -128,6 +128,6 @@ public:
   virtual std::shared_ptr<Organism>
   makeMutatedOffspringFromMany(std::vector<std::shared_ptr<Organism>> from);
   virtual std::shared_ptr<Organism>
-  makeCopy(std::shared_ptr<ParametersTable> _PT = nullptr);
+  makeCopy(std::shared_ptr<ParametersTable> PT_ = nullptr);
 };
 

--- a/World/AbstractWorld.h
+++ b/World/AbstractWorld.h
@@ -31,7 +31,7 @@ public:
 
   std::vector<std::string> popFileColumns;
 
-  AbstractWorld(std::shared_ptr<ParametersTable> _PT) : PT(_PT) {}
+  AbstractWorld(std::shared_ptr<ParametersTable> PT_) : PT(PT_) {}
   virtual ~AbstractWorld() = default;
 
   virtual std::unordered_map<std::string, std::unordered_set<std::string>>

--- a/World/BerryWorld/BerryWorld.cpp
+++ b/World/BerryWorld/BerryWorld.cpp
@@ -405,8 +405,8 @@ bool BerryWorld::WorldMap::loadMap(ifstream& FILE, const string _fileName) {
 	return goodRead;
 }
 
-BerryWorld::BerryWorld(shared_ptr<ParametersTable> _PT) :
-		AbstractWorld(_PT) {
+BerryWorld::BerryWorld(shared_ptr<ParametersTable> PT_) :
+		AbstractWorld(PT_) {
 
 	cout << "Berry world setup:" << endl;
 

--- a/World/BerryWorld/BerryWorld.h
+++ b/World/BerryWorld/BerryWorld.h
@@ -296,7 +296,7 @@ public:
 
 	vector<vector<vector<Point2d>>> perfectSensorSites;
 
-	BerryWorld(shared_ptr<ParametersTable> _PT);
+	BerryWorld(shared_ptr<ParametersTable> PT_);
 	virtual ~BerryWorld() = default;
 
 	virtual void evaluate(map<string, shared_ptr<Group>>& groups, int analyse, int visualize, int debug) override;

--- a/World/TestWorld/TestWorld.cpp
+++ b/World/TestWorld/TestWorld.cpp
@@ -20,8 +20,8 @@ shared_ptr<ParameterLink<int>> TestWorld::evaluationsPerGenerationPL = Parameter
 shared_ptr<ParameterLink<string>> TestWorld::groupNamePL = Parameters::register_parameter("WORLD_TEST_NAMES-groupNameSpace", (string)"root::", "namespace of group to be evaluated");
 shared_ptr<ParameterLink<string>> TestWorld::brainNamePL = Parameters::register_parameter("WORLD_TEST_NAMES-brainNameSpace", (string)"root::", "namespace for parameters used to define brain");
 
-TestWorld::TestWorld(shared_ptr<ParametersTable> _PT) :
-		AbstractWorld(_PT) {
+TestWorld::TestWorld(shared_ptr<ParametersTable> PT_) :
+		AbstractWorld(PT_) {
 
 	// columns to be added to ave file
 	popFileColumns.clear();

--- a/World/XorWorld/XorWorld.cpp
+++ b/World/XorWorld/XorWorld.cpp
@@ -20,10 +20,10 @@ shared_ptr<ParameterLink<string>> XorWorld::brainNamePL = Parameters::register_p
 shared_ptr<ParameterLink<int>> XorWorld::evaluationsPerGenerationPL = Parameters::register_parameter("WORLD_XOR-evaluationsPerGeneration", 1, "Number of times to test each Genome per generation (useful with non-deterministic brains)");
 shared_ptr<ParameterLink<int>> XorWorld::brainUpdatesPL = Parameters::register_parameter("WORLD_XOR-brainUpdates", 10, "Number of times the brain gets to receive input and perform 1 brain update, before the brain's output is queried.");
 
-XorWorld::XorWorld(shared_ptr<ParametersTable> _PT) :AbstractWorld(_PT) {
+XorWorld::XorWorld(shared_ptr<ParametersTable> PT_) :AbstractWorld(PT_) {
 	
-	groupName = groupNamePL->get(_PT);
-	brainName = brainNamePL->get(_PT);
+	groupName = groupNamePL->get(PT_);
+	brainName = brainNamePL->get(PT_);
      brainUpdates = brainUpdatesPL->get(PT);
 	
 	// columns to be added to ave file

--- a/World/XorWorld/XorWorld.h
+++ b/World/XorWorld/XorWorld.h
@@ -29,7 +29,7 @@ public:
 	string groupName;
 	string brainName;
 	
-	XorWorld(shared_ptr<ParametersTable> _PT = nullptr);
+	XorWorld(shared_ptr<ParametersTable> PT_ = nullptr);
 	virtual ~XorWorld() = default;
 	virtual void evaluateSolo(shared_ptr<Organism> org, int analyze, int visualize, int debug) override;
 	virtual void evaluate(map<string, shared_ptr<Group>>& groups, int analyze, int visualize, int debug) {


### PR DESCRIPTION
 N4659(5.10 [lex.name])
3 ... some identifiers are reserved for use by C ++ implementations and shall not be used otherwise; no
diagnostic is required.
(3.1) — Each identifier that contains a double underscore __ or begins with an underscore followed by an
uppercase letter is reserved to the implementation for any use.