### PR TITLE
seq() gives error message and exits on input with incorrect syntax

### DIFF
--- a/Utilities/Utilities.h
+++ b/Utilities/Utilities.h
@@ -193,6 +193,8 @@ inline static bool load_value(const std::string &value, T &target) {
   return ss >> target ? !(ss >> remaining) : false;
 }
 
+// Put an arbitrary value to the target variable, return false on conversion
+// failure (COPIES FUNCTION OF load_value()!)
 template <class T>
 inline static bool stringToValue(const std::string &source, T &target) {
   std::stringstream ss(source);
@@ -319,11 +321,18 @@ inline std::vector<int> seq(const std::string sequence_string,
                             int default_max = -1, bool add_zero = false) {
   std::set<int> result;
   // as described above
-  std::regex sequence( // needs to be documented somewhere
-      R"((?:(\d+)|(?:(?:(?:(\d+)-)?(\d+))?(?::(\d+))?))(?:,|$))");
-  for (auto &m : forEachRegexMatch(sequence_string, sequence)) {
-    if (m[0].str().empty())
-      continue;
+  std::regex commas(
+      R"(([^,]+)(?:,|$))");
+  std::regex sub_seq( // needs to be documented somewhere
+      R"((\d+)|(?:(?:(?:(\d+)-)?(\d+))?(?::(\d+))?))");
+  for (auto & sub_seq_match : forEachRegexMatch(sequence_string, commas)) {
+	std::string sub = sub_seq_match[1].str();
+    std::smatch m;
+    if (!std::regex_match(sub, m, sub_seq)) {
+      std::cout << " Error : sequence " << sequence_string
+                << " cannot be parsed";
+      exit(1);
+    }
     if (!m[1].str().empty()) {
       result.insert(std::stoi(m[1].str()));
       continue;


### PR DESCRIPTION
seq() may return empty list, but exits gracefully on incorrect input syntax.