### PR TITLE
refactored, fixed, and updated the 'required modules auto install' code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,18 @@ compiler:
 branches:
   only:
   - development
+  - master
   - "/feature.*/"
   - "/hotfix.*/"
 
 addons:
   apt:
     packages:
-      - python3
+      - python3.6
       - cmake
     sources: &sources
+      - deadsnakes
       - ubuntu-toolchain-r-test
-
-#before_install:
-#  # C++14
-#  - sudo apt-get update -qq
 
 install: 
   # C++14
@@ -32,7 +30,7 @@ install:
 script:
   - cp .travis.buildOptions.txt buildOptions.txt
   - ls
-  - python3 --version
+  - python3.6 --version
   - g++ --version
-  - python3 pythonTools/mbuild.py -g make
+  - python3.6 pythonTools/mbuild.py -g make
   - make -j4

--- a/pythonTools/mbuild.py
+++ b/pythonTools/mbuild.py
@@ -8,7 +8,6 @@ import collections ## defaultdict
 from utils import pyreq
 from subprocess import call
 
-
 if platform.system() == 'Windows':
     pyreq.require("winreg") ## quits if had to attempt install. So user must run script again.
     import winreg ## can now safely import

--- a/pythonTools/mbuild.py
+++ b/pythonTools/mbuild.py
@@ -5,21 +5,12 @@ import sys
 import platform ## system identification
 import uuid ## unique guid generator for vs project files
 import collections ## defaultdict
-import imp # module dependency checking
+from utils import pyreq
 from subprocess import call
 
 
 if platform.system() == 'Windows':
-    requiredNonstandardModules = "winreg".split(',')
-    modulesAreMissing = False
-    for moduleName in requiredNonstandardModules:
-        try:
-            imp.find_module(moduleName)
-        except (ModuleNotFoundError,ImportError) as error:
-            modulesAreMissing = True
-    if modulesAreMissing:
-        print("Error: required 'winreg' module is missing. Try installing it, or install miniconda python3 for windows.")
-        sys.exit()
+    pyreq.require("winreg") ## quits if had to attempt install. So user must run script again.
     import winreg ## can now safely import
 
 parser = argparse.ArgumentParser()

--- a/pythonTools/mgraph.py
+++ b/pythonTools/mgraph.py
@@ -5,6 +5,7 @@
 import argparse
 parser = argparse.ArgumentParser()
 
+pyreq.require("matplotlib,numpy,scipy,pandas")
 
 parser.add_argument('-path', type=str, metavar='PATH', default = '',  help='path to files - default : none (will read files in current directory)', required=False)
 parser.add_argument('-conditions', type=str, metavar=('CONDITION'), default = [''],  help='names of condition directories - default: none (will use files in path directly)',nargs='+', required=False)

--- a/pythonTools/mq.py
+++ b/pythonTools/mq.py
@@ -34,7 +34,7 @@ import re
 from utils import pyreq
 import subprocess # invoking command line module installation
 
-pyreq.require("colorama,psutil") # quites if not found, even after it installs. must run this script again
+pyreq.require("colorama,psutil") # quits if not found, even after it installs. must run this script again
 
 # colored warning and error printing
 import colorama

--- a/pythonTools/mq.py
+++ b/pythonTools/mq.py
@@ -31,66 +31,10 @@ import datetime
 import getpass  # for getuser() gets current username
 import itertools # for generating combinations of conditions
 import re
-import imp # module dependency checking
+from utils import pyreq
 import subprocess # invoking command line module installation
 
-suitableModuleInstallers = "conda,pip3,pip".split(',')
-requiredNonstandardModules = "colorama,psutil".split(',')
-installCMDString = ''
-modulesAreMissing = False
-def testForModuleAndBuildInstallString(moduleName):
-    global installCMDString, modulesAreMissing
-    try:
-        imp.find_module(moduleName)
-    except ImportError:
-        installCMDString += moduleName+' '
-        modulesAreMissing = True
-def executableExistsInPath(exename,separator):
-    foundPath = None
-    for extension in ['','.exe']:
-        if foundPath is not None:
-            break
-        for path in os.environ["PATH"].split(os.pathsep):
-            if foundPath is not None:
-                break
-            fp = os.path.join(path,exename).replace(os.pathsep,separator)
-            if os.path.isfile(fp): #and os.access(os.path.join(path,exename),os.X_OK):
-                foundPath = fp
-    return foundPath
-for moduleName in requiredNonstandardModules:
-    testForModuleAndBuildInstallString(moduleName)
-if modulesAreMissing:
-    print("Error: Required python modules are missing: {modules}".format(modules=', '.join(installCMDString.split())))
-    print()
-    response = 'NoInput'
-    while response not in ['','y','n','yes','no']:
-        response = input("Should I try to install them? [Y/n] (Enter defaults yes): ").lower()
-    if response in ['','y','yes']:
-        preferredInstaller = None
-        for eachInstaller in suitableModuleInstallers:
-            installerPath = executableExistsInPath(eachInstaller,'/') # handles *nix and *nix-on-win
-            if installerPath is not None:
-                preferredInstaller = eachInstaller
-                break
-            installerPath = executableExistsInPath(eachInstaller,'\\') # handles running on standard win
-            if installerPath is not None:
-                preferredInstaller = eachInstaller
-                break
-        if preferredInstaller is None:
-            print("Error: no suitable python installer found of either "+', '.join(suitableModuleInstallers))
-            print("       Please run the following command using your python module installer:")
-            print("       "+preferredInstaller + ' install '+installCMDString)
-            sys.exit(1)
-        print("Found module installer "+preferredInstaller)
-        try:
-            subprocess.run(preferredInstaller + ' install '+installCMDString, shell=True, check=True)
-        except subprocess.CalledProcessError:
-            print("Error: module installation using the following installation system failed:")
-            print("       "+preferredInstaller)
-            sys.exit(1)
-        print()
-        print("Installation success. Please try to run the script as you were again (press the up arrow on your keyboard to recall previous commands).")
-    sys.exit(0)
+pyreq.require("colorama,psutil") # quites if not found, even after it installs. must run this script again
 
 # colored warning and error printing
 import colorama

--- a/pythonTools/utils/pyreq.py
+++ b/pythonTools/utils/pyreq.py
@@ -1,0 +1,130 @@
+import os
+import sys
+import imp # module dependency checking
+import subprocess # invoking command line module installation
+
+suitableModuleInstallers = "conda,pip3,pip".split(',')
+preferredInstaller='' ## probably conda, but might be pip
+alternateInstaller='' ## probably pip
+installCMDString = ''
+modulesAreMissing = False
+
+def testForModuleAndBuildInstallString(moduleName):
+    global installCMDString, modulesAreMissing
+    ## the split(':') allows there to exist
+    ## strings like "bzip2:bz2" meaning "installName:importName"
+    ## when there is a difference. If they are the same, then
+    ## "colorama" without the ':' will suffice.
+    try:
+        imp.find_module(moduleName.split(':')[-1])
+    except ImportError:
+        installCMDString += moduleName.split(':')[0]+' '
+        modulesAreMissing = True
+
+def executableExistsInPath(exename,separator):
+    foundPath = None
+    for extension in ['','.exe']:
+        if foundPath is not None:
+            break
+        for path in os.environ["PATH"].split(os.pathsep):
+            if foundPath is not None:
+                break
+            fp = os.path.join(path,exename).replace(os.pathsep,separator)+extension
+            if os.path.isfile(fp): #and os.access(os.path.join(path,exename),os.X_OK):
+                foundPath = fp
+    return foundPath
+
+def reportPath():
+    print(os.environ["PATH"].split(os.pathsep))
+
+def reportInstaller():
+    global preferredInstaller, alternateInstaller
+    for eachInstaller in suitableModuleInstallers:
+        installerPath = executableExistsInPath(eachInstaller,'/') # handles *nix and *nix-on-win
+        if installerPath is not None:
+            if preferredInstaller == '':
+                preferredInstaller = eachInstaller
+                continue
+            else:
+                alternateInstaller = eachInstaller
+                break
+        installerPath = executableExistsInPath(eachInstaller,'\\') # handles running in standard win
+        if installerPath is not None:
+            if preferredInstaller == '':
+                preferredInstaller = eachInstaller
+                continue
+            else:
+                alternateInstaller = eachInstaller
+                break
+    if preferredInstaller == '':
+        print("Error: no suitable python installer found of either "+', '.join(suitableModuleInstallers))
+        print("       Please run the following command using your python module installer:")
+        print("       "+preferredInstaller + ' install '+installCMDString)
+        sys.exit(1)
+    #print("Found module installer "+preferredInstaller)
+    #print("Found alternate installer "+alternateInstaller)
+
+def require(names): ## the only exported fn
+    global installCMDString, modulesAreMissing, preferredInstaller, alternateInstaller, suitableModuleInstallers
+    '''names = a comma separated string of module names, no spaces.
+    Can handle packages where the install name is not the same as the import name
+    "packagename,packagename,..."
+    "packagename,packagename:importname,packagename:importname,..."
+    example: pyreq.require("colorama,psutil")
+    example: pyreq.require("winreg,beautifulsoup4:bs4")'''
+
+    requiredNonstandardModules = names.split(',')
+    requiredNonstandardModules = set(requiredNonstandardModules) ## remove dups
+    for moduleName in requiredNonstandardModules:
+        testForModuleAndBuildInstallString(moduleName)
+    if modulesAreMissing:
+        print("Error: Required python modules are missing: {modules}".format(modules=', '.join(installCMDString.split())))
+        print()
+        response = 'NoInput'
+        while response not in ['','y','n','yes','no']:
+            response = input("Should I try to install them? [Y/n] (Enter defaults yes): ").lower()
+        if response in ['','y','yes']:
+            preferredInstaller = ''
+            for eachInstaller in suitableModuleInstallers:
+                installerPath = executableExistsInPath(eachInstaller,'/') # handles *nix and *nix-on-win
+                if installerPath is not None:
+                    if preferredInstaller == '':
+                        preferredInstaller = eachInstaller
+                        continue
+                    else:
+                        alternateInstaller = eachInstaller
+                        break
+                installerPath = executableExistsInPath(eachInstaller,'\\') # handles running on standard win
+                if installerPath is not None:
+                    if preferredInstaller == '':
+                        preferredInstaller = eachInstaller
+                        continue
+                    else:
+                        alternateInstaller = eachInstaller
+                        break
+            if preferredInstaller is None:
+                print("Error: no suitable python installer found of either "+', '.join(suitableModuleInstallers))
+                print("       Please run the following command using your python module installer:")
+                print("       "+preferredInstaller + ' install '+installCMDString)
+                sys.exit(1)
+            print("Found module installer "+preferredInstaller)
+            print("Found alternate installer "+alternateInstaller)
+            try:
+                subprocess.run(preferredInstaller + ' install '+installCMDString, shell=True, check=True)
+            except subprocess.CalledProcessError:
+                print("Module not found using '"+preferredInstaller+"', trying '"+alternateInstaller+"'...")
+                try:
+                    subprocess.run(alternateInstaller + ' install '+installCMDString, shell=True, check=True)
+                except subprocess.CalledProcessError:
+                    print("Error: module installation using the following installation system failed:")
+                    print("       "+preferredInstaller)
+                    sys.exit(1)
+            print()
+            print("No obvious errors I could detect. Please try to run the script as you were again (press the up arrow on your keyboard to recall previous commands).")
+        sys.exit(0)
+
+def tests():
+    pass
+
+if __name__ == '__main__':
+    tests()

--- a/pythonTools/utils/pyreq.py
+++ b/pythonTools/utils/pyreq.py
@@ -9,6 +9,9 @@ alternateInstaller='' ## probably pip
 installCMDString = ''
 modulesAreMissing = False
 
+## user flag for "pip install --user" empty if not needed. Mostly this is for HPCC installation after "module load Python/3.5.3"
+userFlag = "--user " if subprocess.run("sudo -v",shell=True,stderr=subprocess.PIPE,stdout=subprocess.PIPE).stderr.startswith(b"Sorry") else ""
+
 def testForModuleAndBuildInstallString(moduleName):
     global installCMDString, modulesAreMissing
     ## the split(':') allows there to exist
@@ -110,11 +113,11 @@ def require(names): ## the only exported fn
             print("Found module installer "+preferredInstaller)
             print("Found alternate installer "+alternateInstaller)
             try:
-                subprocess.run(preferredInstaller + ' install '+installCMDString, shell=True, check=True)
+                subprocess.run(preferredInstaller + ' install '+userFlag+installCMDString, shell=True, check=True)
             except subprocess.CalledProcessError:
                 print("Module not found using '"+preferredInstaller+"', trying '"+alternateInstaller+"'...")
                 try:
-                    subprocess.run(alternateInstaller + ' install '+installCMDString, shell=True, check=True)
+                    subprocess.run(alternateInstaller + ' install '+userFlag+installCMDString, shell=True, check=True)
                 except subprocess.CalledProcessError:
                     print("Error: module installation using the following installation system failed:")
                     print("       "+preferredInstaller)


### PR DESCRIPTION
This makes the mTools code cleaner and reduces code duplication. We can also reuse this tool in the future. It looks for python installers: conda,pip3,pip in that order.

Usage looks like this:
```
from utils import pyreq
pyreq.require("installNameA,installNameB:importNameB") ## quits if it had to install stuff for you
import installNameA, importNameB
```

After installation, it says you should now be good to go to rerun the script you were trying to run, without issues.