### PR TITLE
pop loader looks at corresponding data file to use the attributes

### DIFF
--- a/Utilities/Loader.cpp
+++ b/Utilities/Loader.cpp
@@ -144,8 +144,13 @@ std::string Loader::findAndGenerateAllFiles(std::string all_lines) {
     all_possible_file_names.push_back(std::experimental::filesystem::path(p).generic_string());
   }
   */
-  zz::fs::Directory mabe_dir("./", "*organisms*.csv", true); // true=recursive
-  for (auto p : mabe_dir) {
+  zz::fs::Directory mabe_org_dir("./", "*organisms*.csv", true); // true=recursive
+  for (auto p : mabe_org_dir) {
+  	  all_possible_file_names.push_back(p.relative_path());
+  }
+  
+  zz::fs::Directory mabe_data_dir("./", "*data*.csv", true); // true=recursive
+  for (auto p : mabe_data_dir) {
   	  all_possible_file_names.push_back(p.relative_path());
   }
 


### PR DESCRIPTION
For every organism file, the corresponding data file might need to be used, so we add that to the list of all possible file names.