### PR TITLE
Patch stuff

### DIFF
--- a/Archivist/DefaultArchivist.cpp
+++ b/Archivist/DefaultArchivist.cpp
@@ -8,6 +8,7 @@
 //     to view the full license, visit:
 //         github.com/Hintzelab/MABE/wiki/License
 
+#include<limits>
 #include "DefaultArchivist.h"
 
 ////// ARCHIVIST-outputMethod is actually set by Modules.h //////
@@ -201,7 +202,7 @@ void DefaultArchivist::writeRealTimeFiles(
   if (writeMaxFile && max_formula_ != nullptr) {
 
     std::shared_ptr<Organism> best_org;
-    auto score = -1.f;
+    auto score = std::numeric_limits<double>::min(); 
     for (auto org : population)
       if (org->timeOfBirth < Global::update || save_new_orgs_) {
         auto sc = max_formula_->eval(org->dataMap, org->PT)[0];
@@ -211,7 +212,7 @@ void DefaultArchivist::writeRealTimeFiles(
         }
       }
 
-    if (score < 0) {
+    if (score == std::numeric_limits<double>::min()) {
       std::cout
           << " Error: could not find Max score organism to save to MaxFile"
           << std::endl;

--- a/Global.cpp
+++ b/Global.cpp
@@ -22,7 +22,7 @@ std::shared_ptr<ParameterLink<int>> Global::updatesPL =
 std::shared_ptr<ParameterLink<std::string>> Global::initPopPL =
     Parameters::register_parameter(
         "GLOBAL-initPop", (std::string) "MASTER = default 100",
-        "initial population to start MABE (if it's .plf syntax it will be \n"
+        "initial population to start MABE (if it's .plf syntax it will be "
         "parsed as such. If it's a file name with .plf that population loader "
         "file is parsed");
 std::shared_ptr<ParameterLink<std::string>> Global::modePL =

--- a/Optimizer/SimpleOptimizer/SimpleOptimizer.cpp
+++ b/Optimizer/SimpleOptimizer/SimpleOptimizer.cpp
@@ -27,13 +27,13 @@ std::shared_ptr<ParameterLink<std::string>> SimpleOptimizer::surviveRatePL =
     Parameters::register_parameter("OPTIMIZER_SIMPLE-surviveRate",
                                    (std::string) "0",
                                    "value between 0 and 1, likelyhood that an "
-                                   "organism will self (ignored if "
-                                   "numberParents = 1) (MTree)");
+                                   "organism will survive (MTree)");
 std::shared_ptr<ParameterLink<std::string>> SimpleOptimizer::selfRatePL =
     Parameters::register_parameter("OPTIMIZER_SIMPLE-selfRate",
                                    (std::string) "0",
                                    "value between 0 and 1, likelyhood that an "
-                                   "organism will survive (MTree)");
+                                   "organism will self (ignored if "
+                                   "numberParents = 1) (MTree)");
 std::shared_ptr<ParameterLink<std::string>> SimpleOptimizer::elitismCountPL =
     Parameters::register_parameter("OPTIMIZER_SIMPLE-elitismCount",
                                    (std::string) "1",

--- a/Utilities/Parameters.cpp
+++ b/Utilities/Parameters.cpp
@@ -505,23 +505,26 @@ void Parameters::printParameterWithWraparound(std::stringstream &file,
   auto comment = entire_parameter.substr(pos_of_comment + 3); // + 3 must be cleaned
 
   // add as much of the comment as possible to the line
-  auto next_newline = comment.find_first_of('\n');
-  auto comment_cut = std::min(  // yuck, must express more clearly
-      next_newline == std::string::npos ? max_line_length : int(next_newline),
-      max_line_length - std::max(comment_indent, int(line.length())));
-  line += comment.substr(0, comment_cut);
+  std::regex as_much_of_comment(
+      R"((.*\n|.{1,)" + std::to_string(max_line_length - comment_indent ) +
+      R"(}[^\s]*))");
+  std::smatch a_m_c; 
+  std::regex_search(comment,a_m_c,as_much_of_comment);
+
+  line += a_m_c.str();
   file << line << '\n';
- 
+
+  comment = a_m_c.suffix();
   // write rest of the comments right-aligned
-  comment = comment.substr(std::min(comment_cut , int(comment.length())));
-  std::regex aligned_comments(R"((.*\n|.{1,)" + std::to_string(max_line_length - comment_indent) +
-                              R"(}))");
+  std::regex aligned_comments(
+      R"((.*\n|.{1,)" + std::to_string(max_line_length - comment_indent - 2) +
+      R"(}[^\s]*))");
   for (auto &m : forEachRegexMatch(comment, aligned_comments)) {
     auto comment_piece = m[1].str();
-    file << sub_line << "# " << comment_piece
+    file << sub_line << "  # " << comment_piece
          << (comment_piece.back() == '\n' ? "" : "\n");
   }
-  file << '\n';
+  //file << '\n';
 } // end  Parameters::printParameterWithWraparound
 
 

--- a/Utilities/Parameters.cpp
+++ b/Utilities/Parameters.cpp
@@ -475,7 +475,6 @@ void Parameters::saveSettingsFile(const std::string &name_space,
 
 }  // end  Parameters::saveSettingsFile
 
-
 void Parameters::printParameterWithWraparound(std::stringstream &file,
                                               std::string current_indent,
                                               std::string entire_parameter,
@@ -489,44 +488,44 @@ void Parameters::printParameterWithWraparound(std::stringstream &file,
     exit(1); // which makes type conversion to int safe after this??
   }
   if (int(pos_of_comment) > max_line_length - 9) {
-    std::cout << " Warning: parameter name and value too large to fit on single "
-            "line. Ignoring column width for this line\n";
+    std::cout
+        << " Warning: parameter name and value too large to fit on single "
+           "line. Ignoring column width for this line\n";
   }
 
   std::string line;
   line += current_indent;
-  line += entire_parameter.substr(0, pos_of_comment);  // write name-value
+  line += entire_parameter.substr(0, pos_of_comment); // write name-value
 
   std::string sub_line(comment_indent, ' ');
   if (int(line.length()) < comment_indent)
     line +=
         sub_line.substr(0, comment_indent - line.length()); // pad with spaces
 
-  auto comment = entire_parameter.substr(pos_of_comment + 3); // + 3 must be cleaned
+  auto comment =
+      entire_parameter.substr(pos_of_comment + 3); // + 3 must be cleaned
 
   // add as much of the comment as possible to the line
   std::regex as_much_of_comment(
-      R"((.*\n|.{1,)" + std::to_string(max_line_length - comment_indent ) +
-      R"(}[^\s]*))");
-  std::smatch a_m_c; 
-  std::regex_search(comment,a_m_c,as_much_of_comment);
+      R"(.{1,)" + std::to_string(max_line_length - comment_indent) +
+      R"(}[^\s]*)");
+  std::smatch a_m_c;
+  std::regex_search(comment, a_m_c, as_much_of_comment);
 
   line += a_m_c.str();
   file << line << '\n';
 
   comment = a_m_c.suffix();
-  // write rest of the comments right-aligned
+  // write rest of the comments right-aligned with slight padding
   std::regex aligned_comments(
-      R"((.*\n|.{1,)" + std::to_string(max_line_length - comment_indent - 2) +
-      R"(}[^\s]*))");
+      R"(.{1,)" + std::to_string(max_line_length - comment_indent - 2) +
+      R"(}[^\s]*)");
   for (auto &m : forEachRegexMatch(comment, aligned_comments)) {
-    auto comment_piece = m[1].str();
+    auto comment_piece = m.str();
     file << sub_line << "  # " << comment_piece
          << (comment_piece.back() == '\n' ? "" : "\n");
   }
-  //file << '\n';
 } // end  Parameters::printParameterWithWraparound
-
 
 void Parameters::saveSettingsFiles(
     int max_line_length, int comment_indent,


### PR DESCRIPTION
lower bound on score on organism is now std::numeric_limits<double>::min, in defaultArchivist.

Settings files are now printed more compactly.

Usage message corrected (Fixes #168)