### PR TITLE
Feature build options gens

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,18 @@ compiler:
 branches:
   only:
   - development
+  - master
   - "/feature.*/"
   - "/hotfix.*/"
 
 addons:
   apt:
     packages:
-      - python3
+      - python3.6
       - cmake
     sources: &sources
+      - deadsnakes
       - ubuntu-toolchain-r-test
-
-#before_install:
-#  # C++14
-#  - sudo apt-get update -qq
 
 install: 
   # C++14
@@ -32,7 +30,7 @@ install:
 script:
   - cp .travis.buildOptions.txt buildOptions.txt
   - ls
-  - python3 --version
+  - python3.6 --version
   - g++ --version
-  - python3 pythonTools/mbuild.py -g make
+  - python3.6 pythonTools/mbuild.py -g make
   - make -j4

--- a/pythonTools/mbuild.py
+++ b/pythonTools/mbuild.py
@@ -8,7 +8,6 @@ import collections ## defaultdict
 from utils import pyreq
 from subprocess import call
 
-
 if platform.system() == 'Windows':
     pyreq.require("winreg") ## quits if had to attempt install. So user must run script again.
     import winreg ## can now safely import

--- a/pythonTools/mbuild.py
+++ b/pythonTools/mbuild.py
@@ -5,21 +5,12 @@ import sys
 import platform ## system identification
 import uuid ## unique guid generator for vs project files
 import collections ## defaultdict
-import imp # module dependency checking
+from utils import pyreq
 from subprocess import call
 
 
 if platform.system() == 'Windows':
-    requiredNonstandardModules = "winreg".split(',')
-    modulesAreMissing = False
-    for moduleName in requiredNonstandardModules:
-        try:
-            imp.find_module(moduleName)
-        except (ModuleNotFoundError,ImportError) as error:
-            modulesAreMissing = True
-    if modulesAreMissing:
-        print("Error: required 'winreg' module is missing. Try installing it, or install miniconda python3 for windows.")
-        sys.exit()
+    pyreq.require("winreg") ## quits if had to attempt install. So user must run script again.
     import winreg ## can now safely import
 
 parser = argparse.ArgumentParser()

--- a/pythonTools/mbuild.py
+++ b/pythonTools/mbuild.py
@@ -3,6 +3,8 @@ import os
 import posixpath
 import sys
 import platform ## system identification
+import re ## regular expressions
+import copy ## deepcopy
 import uuid ## unique guid generator for vs project files
 import collections ## defaultdict
 from utils import pyreq
@@ -23,6 +25,7 @@ parser.add_argument('-nc','--noCompile', action='store_true', default = False, h
 parser.add_argument('-g','--generate', type=str, default = 'none', help='does not compile but generates a project files of type: '+SUPPORTED_PROJECT_FILES+' ('+SUPPORTED_PROJECT_NAMES+')', required=False)
 parser.add_argument('-pg','--gprof', action='store_true', default = False, help='compile with -pg option (for gprof)', required=False)
 parser.add_argument('-p','--parallel', default = 1, help='how many threads do you want to use when you compile?  i.e. make -j6', required=False)
+parser.add_argument('-i','--init', action = 'store_true', default = False, help='refresh or initialize the buildOptions.txt', required=False)
 
 args = parser.parse_args()
 
@@ -35,6 +38,66 @@ compiler='c++'
 compFlags='-Wno-c++98-compat -w -Wall -std=c++11 -O3 -lpthread -pthread'
 if (args.gprof):
     compFlags =  compFlags + ' -pg'
+
+options = {'World':[],'Genome':[],'Brain':[],'Optimizer':[],'Archivist':[],}
+currentOption = ""
+
+ptrnBuildOptions = re.compile(r'([+\-*%])\s*(\w+)') # ex: gets ["%","WORLD"] from " %  WORLD", gets ["*","BerryWorld"] from " * BerryWorld"
+if args.init:
+    ## fill options dict with the subdirs names {'World':['Berry','Xor']}
+    for eachTopDir in options.keys():
+        if os.path.isdir(eachTopDir):
+            for eachSubDir in os.listdir(eachTopDir):
+                if os.path.isdir(os.path.join(eachTopDir,eachSubDir)):
+                    options[eachTopDir].append(eachSubDir[0:-len(eachTopDir)])
+                elif eachSubDir.startswith("Default"):
+                    if "Default" not in options[eachTopDir]:
+                        options[eachTopDir].append("Default")
+    open("buildOptions.txt",'a').close() ## create buildOptions.txt if it doesn't exist
+    ## read current buildOptions.txt into a single string
+    f = open("buildOptions.txt",'r')
+    bopts = f.read().splitlines()
+    f.close()
+    ## create a data structure to store buildOptions sections, and include directives [+-*] and names ['Berry','Xor']
+    oldopts = dict()
+    for eachKey in options.keys():
+        oldopts[eachKey] = ([],[]) ## Structure: {'World':(['+','-'],['Berry','Xor']),...}
+    ## go through the old buildOptions, store into the new structure, and remove names from the discovered (options var) if already here
+    ## and also don't add to new structure if not in discovered (options var)
+    OPS,NAMES=0,1
+    currentSection=''
+    for line in bopts:
+        line = line.strip()
+        if len(line) == 0: continue
+        for a,b in ptrnBuildOptions.findall(line):
+            if a == '%': currentSection = b
+            else:
+                if b in options[currentSection]: ## if also in filesystem discovered (options var)
+                    oldopts[currentSection][OPS].append(a) ## add to new structure
+                    oldopts[currentSection][NAMES].append(b)
+                    options[currentSection].remove(b) ## remove from filesystem discovered
+    ## for all remaining items (meaning were discovered but not yet in the new structure) add them to new structure
+    for currentSection,names in options.items():
+        for name in names:
+            oldopts[currentSection][OPS].append('+')
+            oldopts[currentSection][NAMES].append(name)
+        if '*' not in oldopts[currentSection][OPS]:
+            oldopts[currentSection][OPS][-1] = '*'
+    ## write new buildOptions.txt using the new structure
+    with open("buildOptions.txt",'w') as newbopts:
+        for currentSection in oldopts.keys():
+            line = "% {section}\n".format(section=currentSection)
+            newbopts.write(line)
+            print(line,end='')
+            for op,name in zip(oldopts[currentSection][OPS],oldopts[currentSection][NAMES]):
+                line = "  {op} {name}\n".format(op=op,name=name)
+                newbopts.write(line)
+                print(line,end='')
+            newbopts.write("\n")
+            print()
+    print("buildOptions.txt created")
+    print()
+    sys.exit()
 
 args.generate=args.generate.lower()
 if args.generate=='none': # make is default generate option
@@ -49,9 +112,9 @@ else: # don't compile if generate option present
 
 if posixpath.exists(args.buildOptions) is False:
     print()
-    print('buildOptions file with name "'+args.buildOptions+'" does not exist. Please provide a diffrent filename.')
+    print('buildOptions file with name "'+args.buildOptions+'" does not exist. Please provide a diffrent filename, or use -i to initialize one.')
     print()
-    sys.exit();
+    sys.exit()
     
 # load all lines from buildOptions into lines, ignore blank lines
 file = open(args.buildOptions, 'r')
@@ -61,8 +124,6 @@ if pathToMABE == "":
 lines = [line.rstrip('\n').split() for line in file if line.rstrip('\n').split() not in [['EOF']] ]
 file.close()
 
-options = {'World':[],'Genome':[],'Brain':[],'Optimizer':[],'Archivist':[],}
-currentOption = ""
 
 unrecognizedLinesFound=False
 for linenum,line in enumerate(lines):

--- a/pythonTools/mgraph.py
+++ b/pythonTools/mgraph.py
@@ -5,6 +5,7 @@
 import argparse
 parser = argparse.ArgumentParser()
 
+pyreq.require("matplotlib,numpy,scipy,pandas")
 
 parser.add_argument('-path', type=str, metavar='PATH', default = '',  help='path to files - default : none (will read files in current directory)', required=False)
 parser.add_argument('-conditions', type=str, metavar=('CONDITION'), default = [''],  help='names of condition directories - default: none (will use files in path directly)',nargs='+', required=False)

--- a/pythonTools/mq.py
+++ b/pythonTools/mq.py
@@ -34,7 +34,7 @@ import re
 from utils import pyreq
 import subprocess # invoking command line module installation
 
-pyreq.require("colorama,psutil") # quites if not found, even after it installs. must run this script again
+pyreq.require("colorama,psutil") # quits if not found, even after it installs. must run this script again
 
 # colored warning and error printing
 import colorama

--- a/pythonTools/mq.py
+++ b/pythonTools/mq.py
@@ -31,66 +31,10 @@ import datetime
 import getpass  # for getuser() gets current username
 import itertools # for generating combinations of conditions
 import re
-import imp # module dependency checking
+from utils import pyreq
 import subprocess # invoking command line module installation
 
-suitableModuleInstallers = "conda,pip3,pip".split(',')
-requiredNonstandardModules = "colorama,psutil".split(',')
-installCMDString = ''
-modulesAreMissing = False
-def testForModuleAndBuildInstallString(moduleName):
-    global installCMDString, modulesAreMissing
-    try:
-        imp.find_module(moduleName)
-    except ImportError:
-        installCMDString += moduleName+' '
-        modulesAreMissing = True
-def executableExistsInPath(exename,separator):
-    foundPath = None
-    for extension in ['','.exe']:
-        if foundPath is not None:
-            break
-        for path in os.environ["PATH"].split(os.pathsep):
-            if foundPath is not None:
-                break
-            fp = os.path.join(path,exename).replace(os.pathsep,separator)
-            if os.path.isfile(fp): #and os.access(os.path.join(path,exename),os.X_OK):
-                foundPath = fp
-    return foundPath
-for moduleName in requiredNonstandardModules:
-    testForModuleAndBuildInstallString(moduleName)
-if modulesAreMissing:
-    print("Error: Required python modules are missing: {modules}".format(modules=', '.join(installCMDString.split())))
-    print()
-    response = 'NoInput'
-    while response not in ['','y','n','yes','no']:
-        response = input("Should I try to install them? [Y/n] (Enter defaults yes): ").lower()
-    if response in ['','y','yes']:
-        preferredInstaller = None
-        for eachInstaller in suitableModuleInstallers:
-            installerPath = executableExistsInPath(eachInstaller,'/') # handles *nix and *nix-on-win
-            if installerPath is not None:
-                preferredInstaller = eachInstaller
-                break
-            installerPath = executableExistsInPath(eachInstaller,'\\') # handles running on standard win
-            if installerPath is not None:
-                preferredInstaller = eachInstaller
-                break
-        if preferredInstaller is None:
-            print("Error: no suitable python installer found of either "+', '.join(suitableModuleInstallers))
-            print("       Please run the following command using your python module installer:")
-            print("       "+preferredInstaller + ' install '+installCMDString)
-            sys.exit(1)
-        print("Found module installer "+preferredInstaller)
-        try:
-            subprocess.run(preferredInstaller + ' install '+installCMDString, shell=True, check=True)
-        except subprocess.CalledProcessError:
-            print("Error: module installation using the following installation system failed:")
-            print("       "+preferredInstaller)
-            sys.exit(1)
-        print()
-        print("Installation success. Please try to run the script as you were again (press the up arrow on your keyboard to recall previous commands).")
-    sys.exit(0)
+pyreq.require("colorama,psutil") # quites if not found, even after it installs. must run this script again
 
 # colored warning and error printing
 import colorama

--- a/pythonTools/utils/pyreq.py
+++ b/pythonTools/utils/pyreq.py
@@ -1,0 +1,130 @@
+import os
+import sys
+import imp # module dependency checking
+import subprocess # invoking command line module installation
+
+suitableModuleInstallers = "conda,pip3,pip".split(',')
+preferredInstaller='' ## probably conda, but might be pip
+alternateInstaller='' ## probably pip
+installCMDString = ''
+modulesAreMissing = False
+
+def testForModuleAndBuildInstallString(moduleName):
+    global installCMDString, modulesAreMissing
+    ## the split(':') allows there to exist
+    ## strings like "bzip2:bz2" meaning "installName:importName"
+    ## when there is a difference. If they are the same, then
+    ## "colorama" without the ':' will suffice.
+    try:
+        imp.find_module(moduleName.split(':')[-1])
+    except ImportError:
+        installCMDString += moduleName.split(':')[0]+' '
+        modulesAreMissing = True
+
+def executableExistsInPath(exename,separator):
+    foundPath = None
+    for extension in ['','.exe']:
+        if foundPath is not None:
+            break
+        for path in os.environ["PATH"].split(os.pathsep):
+            if foundPath is not None:
+                break
+            fp = os.path.join(path,exename).replace(os.pathsep,separator)+extension
+            if os.path.isfile(fp): #and os.access(os.path.join(path,exename),os.X_OK):
+                foundPath = fp
+    return foundPath
+
+def reportPath():
+    print(os.environ["PATH"].split(os.pathsep))
+
+def reportInstaller():
+    global preferredInstaller, alternateInstaller
+    for eachInstaller in suitableModuleInstallers:
+        installerPath = executableExistsInPath(eachInstaller,'/') # handles *nix and *nix-on-win
+        if installerPath is not None:
+            if preferredInstaller == '':
+                preferredInstaller = eachInstaller
+                continue
+            else:
+                alternateInstaller = eachInstaller
+                break
+        installerPath = executableExistsInPath(eachInstaller,'\\') # handles running in standard win
+        if installerPath is not None:
+            if preferredInstaller == '':
+                preferredInstaller = eachInstaller
+                continue
+            else:
+                alternateInstaller = eachInstaller
+                break
+    if preferredInstaller == '':
+        print("Error: no suitable python installer found of either "+', '.join(suitableModuleInstallers))
+        print("       Please run the following command using your python module installer:")
+        print("       "+preferredInstaller + ' install '+installCMDString)
+        sys.exit(1)
+    #print("Found module installer "+preferredInstaller)
+    #print("Found alternate installer "+alternateInstaller)
+
+def require(names): ## the only exported fn
+    global installCMDString, modulesAreMissing, preferredInstaller, alternateInstaller, suitableModuleInstallers
+    '''names = a comma separated string of module names, no spaces.
+    Can handle packages where the install name is not the same as the import name
+    "packagename,packagename,..."
+    "packagename,packagename:importname,packagename:importname,..."
+    example: pyreq.require("colorama,psutil")
+    example: pyreq.require("winreg,beautifulsoup4:bs4")'''
+
+    requiredNonstandardModules = names.split(',')
+    requiredNonstandardModules = set(requiredNonstandardModules) ## remove dups
+    for moduleName in requiredNonstandardModules:
+        testForModuleAndBuildInstallString(moduleName)
+    if modulesAreMissing:
+        print("Error: Required python modules are missing: {modules}".format(modules=', '.join(installCMDString.split())))
+        print()
+        response = 'NoInput'
+        while response not in ['','y','n','yes','no']:
+            response = input("Should I try to install them? [Y/n] (Enter defaults yes): ").lower()
+        if response in ['','y','yes']:
+            preferredInstaller = ''
+            for eachInstaller in suitableModuleInstallers:
+                installerPath = executableExistsInPath(eachInstaller,'/') # handles *nix and *nix-on-win
+                if installerPath is not None:
+                    if preferredInstaller == '':
+                        preferredInstaller = eachInstaller
+                        continue
+                    else:
+                        alternateInstaller = eachInstaller
+                        break
+                installerPath = executableExistsInPath(eachInstaller,'\\') # handles running on standard win
+                if installerPath is not None:
+                    if preferredInstaller == '':
+                        preferredInstaller = eachInstaller
+                        continue
+                    else:
+                        alternateInstaller = eachInstaller
+                        break
+            if preferredInstaller is None:
+                print("Error: no suitable python installer found of either "+', '.join(suitableModuleInstallers))
+                print("       Please run the following command using your python module installer:")
+                print("       "+preferredInstaller + ' install '+installCMDString)
+                sys.exit(1)
+            print("Found module installer "+preferredInstaller)
+            print("Found alternate installer "+alternateInstaller)
+            try:
+                subprocess.run(preferredInstaller + ' install '+installCMDString, shell=True, check=True)
+            except subprocess.CalledProcessError:
+                print("Module not found using '"+preferredInstaller+"', trying '"+alternateInstaller+"'...")
+                try:
+                    subprocess.run(alternateInstaller + ' install '+installCMDString, shell=True, check=True)
+                except subprocess.CalledProcessError:
+                    print("Error: module installation using the following installation system failed:")
+                    print("       "+preferredInstaller)
+                    sys.exit(1)
+            print()
+            print("No obvious errors I could detect. Please try to run the script as you were again (press the up arrow on your keyboard to recall previous commands).")
+        sys.exit(0)
+
+def tests():
+    pass
+
+if __name__ == '__main__':
+    tests()

--- a/pythonTools/utils/pyreq.py
+++ b/pythonTools/utils/pyreq.py
@@ -9,6 +9,9 @@ alternateInstaller='' ## probably pip
 installCMDString = ''
 modulesAreMissing = False
 
+## user flag for "pip install --user" empty if not needed. Mostly this is for HPCC installation after "module load Python/3.5.3"
+userFlag = "--user " if subprocess.run("sudo -v",shell=True,stderr=subprocess.PIPE,stdout=subprocess.PIPE).stderr.startswith(b"Sorry") else ""
+
 def testForModuleAndBuildInstallString(moduleName):
     global installCMDString, modulesAreMissing
     ## the split(':') allows there to exist
@@ -110,11 +113,11 @@ def require(names): ## the only exported fn
             print("Found module installer "+preferredInstaller)
             print("Found alternate installer "+alternateInstaller)
             try:
-                subprocess.run(preferredInstaller + ' install '+installCMDString, shell=True, check=True)
+                subprocess.run(preferredInstaller + ' install '+userFlag+installCMDString, shell=True, check=True)
             except subprocess.CalledProcessError:
                 print("Module not found using '"+preferredInstaller+"', trying '"+alternateInstaller+"'...")
                 try:
-                    subprocess.run(alternateInstaller + ' install '+installCMDString, shell=True, check=True)
+                    subprocess.run(alternateInstaller + ' install '+userFlag+installCMDString, shell=True, check=True)
                 except subprocess.CalledProcessError:
                     print("Error: module installation using the following installation system failed:")
                     print("       "+preferredInstaller)


### PR DESCRIPTION
Adds following command: "python pythonTools/mbuild.py -i" or "python pythonTools/mbuild.py --init" which does the following:

- discovers all mabe modules that should go into buildOptions.txt
- refreshes or creates buildOptions.txt
- only adds modules that aren't already in buildOptions.txt (so leaving current include ops)
- removes modules that don't exist in the filesystem anymore
- prints to screen before quitting, the new buildOptions.txt content