### PR TITLE
Patch world evaluate solo

### DIFF
--- a/Brain/AbstractBrain.h
+++ b/Brain/AbstractBrain.h
@@ -105,7 +105,6 @@ public:
          << std::endl
          << "Exiting." << std::endl;
     exit(1);
-    return makeCopy();
   }
 
   // Make a brain like the brain that called this function, using genomes and

--- a/Utilities/gitversion.h
+++ b/Utilities/gitversion.h
@@ -1,1 +1,1 @@
-const char *gitversion = "92aa69af308a9bc4809ebf9df416071b2100d738";
+const char *gitversion = "864d7e9bc2d69154f4f773f4d37cb1e6daa1c9f1";

--- a/Utilities/gitversion.h
+++ b/Utilities/gitversion.h
@@ -1,0 +1,1 @@
+const char *gitversion = "92aa69af308a9bc4809ebf9df416071b2100d738";

--- a/World/AbstractWorld.h
+++ b/World/AbstractWorld.h
@@ -45,11 +45,8 @@ public:
   //}
 
   virtual void evaluate(std::map<std::string, std::shared_ptr<Group>> &groups,
-                        int analyze = 0, int visualize = 0, int debug = 0) {
-    std::cout << "  chosen world does not define evaluate()! Exiting."
-              << std::endl;
-    exit(1);
-  };
+                        int analyze = 0, int visualize = 0, int debug = 0) = 0;
+
   virtual void evaluateSolo(std::shared_ptr<Organism> org, int analyze,
                             int visualize, int debug) {
     std::cout << "  chosen world does not define evaluateSolo()! Exiting."

--- a/World/TestWorld/TestWorld.cpp
+++ b/World/TestWorld/TestWorld.cpp
@@ -49,7 +49,7 @@ TestWorld::TestWorld(std::shared_ptr<ParametersTable> PT_)
 
 void TestWorld::evaluateSolo(std::shared_ptr<Organism> org, int analyze,
                              int visualize, int debug) {
-  auto brain = org->brains[brainNamePL->get(PT)];
+  auto brain = org->brain;
   for (int r = 0; r < evaluationsPerGenerationPL->get(PT); r++) {
     brain->resetBrain();
     brain->setInput(0, 1); // give the brain a constant 1 (for wire brain)

--- a/World/XorWorld/XorWorld.cpp
+++ b/World/XorWorld/XorWorld.cpp
@@ -54,7 +54,7 @@ XorWorld::XorWorld(std::shared_ptr<ParametersTable> PT_) : AbstractWorld(PT_) {
 // score 1.0 points accumulated per correct xor answer
 void XorWorld::evaluateSolo(std::shared_ptr<Organism> org, int analyze,
                             int visualize, int debug) {
-  auto brain = org->brains[brainName];
+  auto brain = org->brain;
   double score = 0.0000001;
   int questions[4][2] = {{0, 0}, {0, 1}, {1, 0}, {1, 1}};
   double answers[4] = {0.0, 1.0, 1.0, 0.0};


### PR DESCRIPTION
1) evaluate is made pure-virtual. A world implementer MUST provide this interface.

2) In evaluateSolo for XorWorld, and TestWorld, a new brain was being constructed. But in order for data members of the base class to be copied correctly, the brain needs to be be value-assigned from the brain passed in. 