### PR TITLE
Deprecate old world and organism functions

### DIFF
--- a/Organism/Organism.cpp
+++ b/Organism/Organism.cpp
@@ -78,18 +78,6 @@ Organism::Organism(
     dataMap.merge(brain.second->getStats(prefix));
   }
 
-  if (genomes.count("root::") == 0) {
-    genome = nullptr;
-  } else {
-    genome = genomes["root::"];
-  }
-
-  if (brains.count("root::") == 0) {
-    brain = nullptr;
-  } else {
-    brain = brains["root::"];
-  }
-
   ancestors.insert(ID); // it is it's own Ancestor for data tracking purposes
   snapshotAncestors.insert(ID);
 }
@@ -121,18 +109,6 @@ Organism::Organism(
     std::string prefix;
     (brain.first == "root::") ? prefix = "" : prefix = brain.first;
     dataMap.merge(brain.second->getStats(prefix));
-  }
-
-  if (genomes.count("root::") == 0) {
-    genome = nullptr;
-  } else {
-    genome = genomes["root::"];
-  }
-
-  if (brains.count("root::") == 0) {
-    brain = nullptr;
-  } else {
-    brain = brains["root::"];
   }
 
   parents.push_back(from);
@@ -176,18 +152,6 @@ Organism::Organism(
     dataMap.merge(brain.second->getStats(prefix));
   }
 
-  if (genomes.count("root::") == 0) {
-    genome = nullptr;
-  } else {
-    genome = genomes["root::"];
-  }
-
-  if (brains.count("root::") == 0) {
-    brain = nullptr;
-  } else {
-    brain = brains["root::"];
-  }
-
   for (auto parent : from) {
     parents.push_back(parent); // add this parent to the parents set
     parent->offspringCount++;  // this parent has an(other) offspring
@@ -223,8 +187,6 @@ void Organism::kill() {
   timeOfDeath = Global::update;
   if (!trackOrganism) { // if the archivist is not tracking is organism, we can
                         // clear it's genomes and brains.
-    genome = nullptr;
-    brain = nullptr;
     genomes.clear();
     brains.clear();
   }
@@ -359,18 +321,6 @@ Organism::makeCopy(std::shared_ptr<ParametersTable> PT_) {
   }
   for (auto brain : brains) {
     newOrg->brains[brain.first] = brain.second->makeCopy(brain.second->PT);
-  }
-
-  if (newOrg->genomes.count("root::") == 0) {
-    newOrg->genome = nullptr;
-  } else {
-    newOrg->genome = newOrg->genomes["root::"];
-  }
-
-  if (newOrg->brains.count("root::") == 0) {
-    newOrg->brain = nullptr;
-  } else {
-    newOrg->brain = newOrg->brains["root::"];
   }
 
   newOrg->dataMap = dataMap;

--- a/Organism/Organism.h
+++ b/Organism/Organism.h
@@ -33,8 +33,8 @@ public:
   // after the delay we have the correct data for the given time. key is
   // 'update'. This possibly should be wrapped into Archivist.
 
-  std::shared_ptr<AbstractGenome> genome = nullptr;
-  std::shared_ptr<AbstractBrain> brain = nullptr;
+  //std::shared_ptr<AbstractGenome> genome = nullptr;
+  //std::shared_ptr<AbstractBrain> brain = nullptr;
   std::shared_ptr<ParametersTable> PT;
 
   std::unordered_map<std::string, std::shared_ptr<AbstractGenome>> genomes;
@@ -111,8 +111,8 @@ public:
 
   virtual ~Organism();
 
-  bool hasGenome() { return genome != nullptr; }
-  bool hasBrain() { return brain != nullptr; }
+  //bool hasGenome() { return genome != nullptr; }
+  //bool hasBrain() { return brain != nullptr; }
 
   virtual void kill(); // sets alive = 0 (on org and in dataMap)
 

--- a/Organism/Organism.h
+++ b/Organism/Organism.h
@@ -33,8 +33,6 @@ public:
   // after the delay we have the correct data for the given time. key is
   // 'update'. This possibly should be wrapped into Archivist.
 
-  //std::shared_ptr<AbstractGenome> genome = nullptr;
-  //std::shared_ptr<AbstractBrain> brain = nullptr;
   std::shared_ptr<ParametersTable> PT;
 
   std::unordered_map<std::string, std::shared_ptr<AbstractGenome>> genomes;
@@ -46,9 +44,6 @@ public:
       parents; // parents are pointers to parents of
                // this organism. In asexual populations
                // this will have one element
-  // unordered_set<int> genomeAncestors;  // list of the IDs of organisms in the
-  // last genome file who are ancestors of this organism (genomes saved on
-  // genome interval)
   std::unordered_set<int>
       ancestors; // list of the IDs of organisms in the last data
                  // files who are ancestors of this organism
@@ -70,17 +65,6 @@ public:
   Organism() = delete;
   Organism(
       std::shared_ptr<ParametersTable> PT_ = nullptr); // make an empty organism
-  // Organism(shared_ptr<AbstractGenome> _genome, shared_ptr<AbstractBrain>
-  // _brain, shared_ptr<ParametersTable> PT_ = nullptr);  // make a parentless
-  // organism with a genome, and a brain
-  // Organism(shared_ptr<Organism> from, shared_ptr<AbstractGenome> _genome,
-  // shared_ptr<AbstractBrain> _brain, shared_ptr<ParametersTable> PT_ =
-  // nullptr);  // make an organism with one parent, a genome and a brain
-  // determined from the parents brain type.
-  // Organism(const vector<shared_ptr<Organism>> from,
-  // shared_ptr<AbstractGenome> _genome, shared_ptr<AbstractBrain> _brain,
-  // shared_ptr<ParametersTable> PT_ = nullptr);  // make a organism with many
-  // parents, a genome, and a brain determined from the parents brain type.
 
   Organism(
       std::unordered_map<std::string, std::shared_ptr<AbstractGenome>>
@@ -111,12 +95,8 @@ public:
 
   virtual ~Organism();
 
-  //bool hasGenome() { return genome != nullptr; }
-  //bool hasBrain() { return brain != nullptr; }
-
   virtual void kill(); // sets alive = 0 (on org and in dataMap)
 
-  // virtual vector<string> GetLODItem(string key, shared_ptr<Organism> org);
   virtual std::vector<std::shared_ptr<Organism>>
   getLOD(std::shared_ptr<Organism> org);
   virtual std::shared_ptr<Organism>

--- a/World/AbstractWorld.h
+++ b/World/AbstractWorld.h
@@ -50,10 +50,4 @@ public:
               << std::endl;
     exit(1);
   };
-  virtual void evaluateSolo(std::shared_ptr<Organism> org, int analyze,
-                            int visualize, int debug) {
-    std::cout << "  chosen world does not define evaluateSolo()! Exiting."
-              << std::endl;
-    exit(1);
-  };
 };

--- a/World/AbstractWorld.h
+++ b/World/AbstractWorld.h
@@ -45,9 +45,5 @@ public:
   //}
 
   virtual void evaluate(std::map<std::string, std::shared_ptr<Group>> &groups,
-                        int analyze = 0, int visualize = 0, int debug = 0) {
-    std::cout << "  chosen world does not define evaluate()! Exiting."
-              << std::endl;
-    exit(1);
-  };
+	  int analyze = 0, int visualize = 0, int debug = 0) = 0;
 };

--- a/World/TestWorld/TestWorld.h
+++ b/World/TestWorld/TestWorld.h
@@ -35,7 +35,7 @@ public:
   TestWorld(std::shared_ptr<ParametersTable> PT_ = nullptr);
   virtual ~TestWorld() = default;
 
-  virtual void evaluateSolo(std::shared_ptr<Organism> org, int analyze,
+  void evaluateSolo(std::shared_ptr<Organism> org, int analyze,
                             int visualize, int debug);
   virtual void evaluate(std::map<std::string, std::shared_ptr<Group>> &groups,
                         int analyze, int visualize, int debug) {

--- a/World/XorWorld/XorWorld.cpp
+++ b/World/XorWorld/XorWorld.cpp
@@ -16,16 +16,13 @@
 #include <cmath>
 
 std::shared_ptr<ParameterLink<std::string>> XorWorld::groupNamePL =
-    Parameters::register_parameter("WORLD_XOR_NAMES-groupName",
-                                   (std::string) "root::",
-                                   "name of group to be evaluated");
+    Parameters::register_parameter(
+		"WORLD_XOR_NAMES-groupName", (std::string) "root::",
+        "name of group to be evaluated");
 std::shared_ptr<ParameterLink<std::string>> XorWorld::brainNamePL =
     Parameters::register_parameter(
         "WORLD_XOR_NAMES-brainName", (std::string) "root::",
-        "name of brains used to control organisms\nroot = use empty name "
-        "space\nGROUP:: = use group name space\n\"name\" = use \"name\" "
-        "namespace at root level\nGroup::\"name\" = use GROUP::\"name\" name "
-        "space");
+        "namespace for parameters used to define brain");
 std::shared_ptr<ParameterLink<int>> XorWorld::evaluationsPerGenerationPL =
     Parameters::register_parameter("WORLD_XOR-evaluationsPerGeneration", 1,
                                    "Number of times to test each Genome per "

--- a/World/XorWorld/XorWorld.h
+++ b/World/XorWorld/XorWorld.h
@@ -29,8 +29,8 @@ public:
 
   XorWorld(std::shared_ptr<ParametersTable> PT_ = nullptr);
   virtual ~XorWorld() = default;
-  virtual void evaluateSolo(std::shared_ptr<Organism> org, int analyze,
-                            int visualize, int debug) override;
+  void evaluateSolo(std::shared_ptr<Organism> org, int analyze,
+                            int visualize, int debug);
   virtual void evaluate(std::map<std::string, std::shared_ptr<Group>> &groups,
                         int analyze, int visualize, int debug) {
     int popSize = groups[groupNamePL->get(PT)]->population.size();


### PR DESCRIPTION
removed AbstractWorld function evaluateSolo (and updated Xor world) AND removed genome and brain from Organism. These features had been deprecated but remained in the code for backward compatibility.