### PR TITLE
updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,2 @@
-Utilities/zupply/build
-Utilities/zupply/doc
-Utilities/zupply/examples
-Utilities/zupply/LICENSE
-Utilities/zupply/README.md
-Utilities/zupply/unittest
-Utilities/zupply/src/quickstart.cpp
+Utilities/gitversion.h
+modules.h

--- a/pythonTools/mbuild.py
+++ b/pythonTools/mbuild.py
@@ -42,7 +42,7 @@ def touch(fname, mode=0o666, dir_fd=None, **kwargs): ## from https://stackoverfl
             dir_fd=None if os.supports_fd else dir_fd, **kwargs)
 
 compiler='c++'
-compFlags='-Wno-c++98-compat -w -Wall -std=c++11 -O3 -lpthread -pthread'
+compFlags='-Wno-c++98-compat -w -Wall -std=c++14 -O3 -lpthread -pthread'
 if (args.gprof):
     compFlags =  compFlags + ' -pg'
 


### PR DESCRIPTION
Removes zupply from .gitignore. modules.h and Utilities/gitversion.h must be ignored. If any more files should be ignored, comment on this PR.