### PR TITLE
Patch invalid mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,2 @@
-Utilities/zupply/build
-Utilities/zupply/doc
-Utilities/zupply/examples
-Utilities/zupply/LICENSE
-Utilities/zupply/README.md
-Utilities/zupply/unittest
-Utilities/zupply/src/quickstart.cpp
+Utilities/gitversion.h
+modules.h

--- a/Utilities/gitversion.h
+++ b/Utilities/gitversion.h
@@ -1,1 +1,0 @@
-const char *gitversion = "92aa69af308a9bc4809ebf9df416071b2100d738";

--- a/Utilities/gitversion.h
+++ b/Utilities/gitversion.h
@@ -1,0 +1,1 @@
+const char *gitversion = "92aa69af308a9bc4809ebf9df416071b2100d738";

--- a/main.cpp
+++ b/main.cpp
@@ -165,26 +165,28 @@ int main(int argc, const char *argv[]) {
     for (auto const &group : groups) {
       group.second->archive(1);
     }
+  } else if (Global::modePL->get() == "visualize") {
+    ////////////////////////////////////////////////////////////////////////////////////
+    // visualize mode
+    ////////////////////////////////////////////////////////////////////////////////////
+    std::cout << "\n  You are running MABE in visualize mode."
+              << "\n"
+              << "\n";
+
+    world->evaluate(groups, 0, 1, AbstractWorld::debugPL->get());
+  } else if (Global::modePL->get() == "analyze") {
+    ////////////////////////////////////////////////////////////////////////////////////
+    // analyze mode
+    ////////////////////////////////////////////////////////////////////////////////////
+    std::cout << "\n  You are running MABE in analyze mode."
+              << "\n"
+              << "\n";
+
+    world->evaluate(groups, 1, 0, 0);
   } else {
-    if (Global::modePL->get() == "visualize") {
-      ////////////////////////////////////////////////////////////////////////////////////
-      // visualize mode
-      ////////////////////////////////////////////////////////////////////////////////////
-      std::cout << "\n  You are running MABE in visualize mode."
-                << "\n"
-                << "\n";
-
-      world->evaluate(groups, 0, 1, AbstractWorld::debugPL->get());
-    } else if (Global::modePL->get() == "analyze") {
-      ////////////////////////////////////////////////////////////////////////////////////
-      // analyze mode
-      ////////////////////////////////////////////////////////////////////////////////////
-      std::cout << "\n  You are running MABE in analyze mode."
-                << "\n"
-                << "\n";
-
-      world->evaluate(groups, 1, 0, 0);
-    }
+    std::cout << "error: unrecognized GLOBAL-mode " << Global::modePL->get()
+              << std::endl;
+    exit(1);
   }
   return 0;
 }


### PR DESCRIPTION
mabe goes through list of possible modes [run,analyze,visualize] and shows an error if Global::mode is not one of these.