### PR TITLE
updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,2 @@
-Utilities/zupply/build
-Utilities/zupply/doc
-Utilities/zupply/examples
-Utilities/zupply/LICENSE
-Utilities/zupply/README.md
-Utilities/zupply/unittest
-Utilities/zupply/src/quickstart.cpp
+Utilities/gitversion.h
+modules.h


### PR DESCRIPTION
Removes zupply from .gitignore. modules.h and Utilities/gitversion.h must be ignored. If any more files should be ignored, comment on this PR.