### PR TITLE
added ctrl-c handler

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -44,7 +44,6 @@ void catchCtrlC(int signalID) {
       printf("Early termination requested. Results may be incomplete.\n");
       raise(SIGTERM);
   }
-  signal(SIGINT, catchCtrlC);
   userExitFlag = 1;
   printf("\nQuitting after current update. (ctrl-c again to force quit)\n");
 }

--- a/main.cpp
+++ b/main.cpp
@@ -43,7 +43,6 @@ void catchCtrlC(int signalID) {
   if (userExitFlag==1) {
       printf("Early termination requested. Results may be incomplete.\n");
       raise(SIGTERM);
-      exit(signalID); // user force quit
   }
   signal(SIGINT, catchCtrlC);
   userExitFlag = 1;

--- a/main.cpp
+++ b/main.cpp
@@ -40,8 +40,12 @@
 
 volatile sig_atomic_t userExitFlag = 0;
 void catchCtrlC(int signalID) {
+  if (userExitFlag==1) {
+      printf("Early termination requested. Results may be incomplete.\n");
+      raise(SIGTERM);
+      exit(signalID); // user force quit
+  }
   signal(SIGINT, catchCtrlC);
-  if (userExitFlag==1) exit(0); // user force quit
   userExitFlag = 1;
   printf("\nQuitting after current update. (ctrl-c again to force quit)\n");
 }


### PR DESCRIPTION
Has been tested on:

- [x] Mac
- [x] Linux
- [x] Windows (MinGW/MSYS2) (requires invocation "winpty ./mabe ..." because mintty is broken, but "./mabe" will work just like before this PR so nothing lost)
- [x] Windows (Visual Studio)

I've been meaning to add this for quite a while.
Provides a better user experience than killing MABE in a potentially bad state (before, sometimes it would keep running).

- On first ctrl-c tells user it will quit after current update
- And tells them to do it again to force quit immediately if they don't want to wait
`"\nQuitting after current update. (ctrl-c again to force quit)\n"`
- Allowing MABE to finish current update finishes evolution loop and flushes LOD etc. as usual.

You can test the full functionality by making a giant population size, so updates take a while.