### PR TITLE
Hotfix lod optimizer

### DIFF
--- a/Archivist/LODwAPArchivist/LODwAPArchivist.cpp
+++ b/Archivist/LODwAPArchivist/LODwAPArchivist.cpp
@@ -102,7 +102,7 @@ int LODwAPArchivist::writeLODDataFile(
              effective_MRCA->timeOfBirth,
              Global::updatesPL->get())) { // if there is convergence before the
                                           // next data interval
-    auto current = LOD[next_data_write_ - last_prune_];
+    auto current = LOD[(next_data_write_ - last_prune_) - 1];
     current->dataMap.set("update", next_data_write_);
     current->dataMap.setOutputBehavior("update", DataMap::FIRST);
     time_to_coalescence =
@@ -131,7 +131,7 @@ void LODwAPArchivist::writeLODOrganismFile(
              Global::updatesPL->get())) { // if there is convergence before the
                                           // next data interval
 
-    auto current = LOD[next_organism_write_ - last_prune_];
+    auto current = LOD[(next_organism_write_ - last_prune_) - 1];
     DataMap OrgMap;
     OrgMap.set("ID", current->ID);
     OrgMap.set("update", next_organism_write_);
@@ -186,10 +186,12 @@ bool LODwAPArchivist::archive(std::vector<std::shared_ptr<Organism>> &population
   // get the MRCA
   auto some_org = population[0];
   auto LOD = some_org->getLOD(some_org); // get line of descent
+
   if (flush) // if flush then we don't care about coalescence
-    std::cout << "flushing LODwAP: using population[0] as Most Recent Common "
-                 "Ancestor (MRCA)"
-              << std::endl;
+    std::cout << "flushing LODwAP: organism with ID " << population[0]->ID <<
+      " has been selected to generate Line of Descent."
+      << std::endl;
+
   auto effective_MRCA =
       flush // this assumes that a population was created, but not tested at
           // the end of the evolution loop!
@@ -203,10 +205,17 @@ bool LODwAPArchivist::archive(std::vector<std::shared_ptr<Organism>> &population
   // Save Data
   if (writeDataFile) {
     auto time_to_coalescence = writeLODDataFile(LOD, real_MRCA, effective_MRCA);
-    if (flush)
-      std::cout << "Most Recent Common Ancestor/Time to Coalescence was "
-                << time_to_coalescence << " updates ago." << std::endl;
+    if (flush) {
+      if (real_MRCA->timeOfBirth != -2) {
+	std::cout << "Time to Coalescence for last saved organism on LOD is "
+	<< time_to_coalescence << " updates ago." << std::endl;
+      }
+      else {
+	std::cout << "This run has not coalesced. There no Most Recent Common Ancestor." << std::endl;
+      }
+    }
   }
+
 
   // Save Organisms
   if (writeOrganismFile)

--- a/Archivist/LODwAPArchivist/LODwAPArchivist.h
+++ b/Archivist/LODwAPArchivist/LODwAPArchivist.h
@@ -62,7 +62,7 @@ public:
  
   std::string data_file_name_;          // name of the Data file
   std::string organism_file_name_;      // name of the Genome file (genomes on LOD)
-  int last_prune_ = 0; // last time Genome was Pruned
+  int last_prune_ = -1; // last time Genome was Pruned
 
   //// info about files under management
   int next_data_write_;     // next time data files will be written to disk

--- a/Global.cpp
+++ b/Global.cpp
@@ -17,7 +17,7 @@ std::shared_ptr<ParameterLink<int>> Global::randomSeedPL =
                                    "random number generator will be seeded "
                                    "randomly");
 std::shared_ptr<ParameterLink<int>> Global::updatesPL =
-    Parameters::register_parameter("GLOBAL-updates", 50,
+    Parameters::register_parameter("GLOBAL-updates", 100,
                                    "how long the program will run");
 std::shared_ptr<ParameterLink<std::string>> Global::initPopPL =
     Parameters::register_parameter(

--- a/Utilities/Data.h
+++ b/Utilities/Data.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <sstream>
 #include <map>
+#include <memory>
 #include <unordered_map>
 #include <vector>
 

--- a/main.cpp
+++ b/main.cpp
@@ -125,8 +125,9 @@ int main(int argc, const char *argv[]) {
 
   std::shared_ptr<ParametersTable> PT;
   auto groups = constructAllGroupsFrom(world, PT);
-  Global::update =
-      0; // the beginning of time - now we construct the first population
+
+  Global::update = 0;
+
 
   if (Global::modePL->get() == "run") {
     ////////////////////////////////////////////////////////////////////////////////////
@@ -207,10 +208,6 @@ constructAllGroupsFrom(std::shared_ptr<AbstractWorld> world,
     // parameters table with this name
 
     std::cout << "Building group with name space: " << groupInfo.first << "\n";
-
-    Global::update = -1; // before there was time, there was a progenitor - set
-                         // time to -1 so progenitor (the root organism) will
-                         // have birth time -1
 
     // create an optimizer of type defined by OPTIMIZER-optimizer
     auto optimizer = makeOptimizer(PT);
@@ -332,8 +329,10 @@ constructAllGroupsFrom(std::shared_ptr<AbstractWorld> world,
 	std::cout << std::flush;
     // make a organism with a templateGenomes and templateBrains - progenitor
     // serves as an ancestor to all and a template organism
-    auto progenitor =
+    Global::update = -2; // in the begining there was a projenitor
+      auto progenitor =
         std::make_shared<Organism>(templateGenomes, templateBrains, PT);
+    Global::update = -1; // then in the image of the projenitor the first generation was cafted
 
     std::vector<std::shared_ptr<Organism>> population;
 


### PR DESCRIPTION
This fix corrects 2 things
a) the report at the end of a LOD run was confusing under some conditions. The message being displayed is more informative.
b) progenitor and fir generation orgs both had time of birth -1, now progenitor is -2.