### PR TITLE
short style category names allowed

### DIFF
--- a/Utilities/Parameters.cpp
+++ b/Utilities/Parameters.cpp
@@ -282,10 +282,12 @@ Parameters::readParametersFile(std::string file_name) {
 	}
 
     {
-      std::regex name_value_pair(R"(^\s*(\w+)\s*=\s*(\S?.*\S)\s*$)");
+      std::regex name_value_pair(R"(^\s*([-\w]+)\s*=\s*(\S?.*\S)\s*$)");
       std::smatch m;
       if (std::regex_match(line, m, name_value_pair)) {
-        auto name = name_space_name + category_name + "-" + m[1].str();
+        auto name = name_space_name +
+                    (category_name.empty() ? "" : (category_name + "-")) +
+                    m[1].str();
         if (config_file_list.find(name) != config_file_list.end()) {
           std::cout << "  Error: \"" << name << "\" is defined more then once in file: \""
                << file_name << "\".\n exiting.\n";

--- a/Utilities/Parameters.cpp
+++ b/Utilities/Parameters.cpp
@@ -282,7 +282,7 @@ Parameters::readParametersFile(std::string file_name) {
 	}
 
     {
-      std::regex name_value_pair(R"(^\s*([-\w]+)\s*=\s*(\S?.*\S)\s*$)");
+      std::regex name_value_pair(R"(^\s*([\S]+)\s*=\s*(\S?.*\S)\s*$)");
       std::smatch m;
       if (std::regex_match(line, m, name_value_pair)) {
         auto name = name_space_name +


### PR DESCRIPTION
Parameters in settings files can now be 
%
AA-val = 1

or 
% AA
  val =1 

Both mean the same.

Fixes #208 