### PR TITLE
changed regex definition in parseCSVLine to not be static

### DIFF
--- a/Utilities/Utilities.h
+++ b/Utilities/Utilities.h
@@ -88,9 +88,7 @@ inline std::vector<std::string> parseCSVLine(std::string raw_line,
                                              const char separator = ',',
                                              const char sep_except = '"') {
   std::vector<std::string> data_line;
-  std::string s, se;
-  s = separator;
-  se = sep_except;
+  std::string s(1,separator), se(1,sep_except);
   const std::regex piece(R"((.*?)()" + s + "|" + se + R"(|$))");
   bool in_quotes = false;
   std::string quoted_string;

--- a/Utilities/Utilities.h
+++ b/Utilities/Utilities.h
@@ -89,9 +89,9 @@ inline std::vector<std::string> parseCSVLine(std::string raw_line,
                                              const char sep_except = '"') {
   std::vector<std::string> data_line;
   std::string s, se;
-  s += separator;
-  se += sep_except;
-  static const std::regex piece(R"((.*?)()" + s + "|" + se + R"(|$))");
+  s = separator;
+  se = sep_except;
+  const std::regex piece(R"((.*?)()" + s + "|" + se + R"(|$))");
   bool in_quotes = false;
   std::string quoted_string;
   for (auto &m : forEachRegexMatch(raw_line, piece)) {


### PR DESCRIPTION
the seperator argument was not effective after the first call because the static regex was not being reassigned.