### PR TITLE
Patch wrap parameter

### DIFF
--- a/Utilities/Parameters.cpp
+++ b/Utilities/Parameters.cpp
@@ -566,7 +566,7 @@ void Parameters::printParameterWithWraparound(
   comment = sub_comment.suffix();
   for (auto &m : forEachRegexMatch(comment, aligned_comments)) {
     auto comment_piece = m.str();
-    file << std::string(comment_indent, ' ') << "#  " << comment_piece
+    file << std::string(comment_indent, ' ') << "# " << comment_piece
          << (comment_piece.back() == '\n' ? "" : "\n");
   }
 } // end  Parameters::printParameterWithWraparound

--- a/Utilities/Parameters.cpp
+++ b/Utilities/Parameters.cpp
@@ -545,7 +545,8 @@ void Parameters::printParameterWithWraparound(
   comment = std::regex_replace(comment, new_line, "\n ");
 
   // add as much of the comment as possible to the line
-  static const std::regex as_much_of_comment(
+  std::cout << line.length() <<  line << std::endl;
+  const std::regex as_much_of_comment(
       R"(.{1,)" + std::to_string(max_line_length - line.length() - 2) +
       R"(}[^\s]*)");
   std::smatch a_m_c;
@@ -556,7 +557,7 @@ void Parameters::printParameterWithWraparound(
 
   comment = a_m_c.suffix();
   // write rest of the comments right-aligned with slight padding
-  static const std::regex aligned_comments(
+  const std::regex aligned_comments(
       R"(.{1,)" + std::to_string(max_line_length - comment_indent - 3) +
       R"(}[^\s]*)");
   for (auto &m : forEachRegexMatch(comment, aligned_comments)) {

--- a/Utilities/Parameters.cpp
+++ b/Utilities/Parameters.cpp
@@ -281,10 +281,9 @@ Parameters::readParametersFile(const std::string &file_name) {
       std::regex name_value_pair(R"(^\s*([\S]+)\s*=\s*(\S?.*\S)\s*$)");
       std::smatch m;
       if (std::regex_match(line, m, name_value_pair)) {
-        auto name =
-            name_space_name
-                .append((category_name.empty() ? "" : (category_name + "-")))
-                .append(m[1].str());
+        auto name = name_space_name;
+        name.append((category_name.empty() ? "" : (category_name + "-")))
+            .append(m[1].str());
         if (config_file_list.find(name) != config_file_list.end()) {
           std::cout << "  Error: \"" << name
                     << "\" is defined more then once in file: \"" << file_name

--- a/Utilities/Parameters.cpp
+++ b/Utilities/Parameters.cpp
@@ -533,7 +533,7 @@ void Parameters::printParameterWithWraparound(
 
   // extract comment
   auto comment =
-      entire_parameter.substr(pos_of_comment + 4); // + 3 must be cleaned
+      entire_parameter.substr(pos_of_comment + 5); // + 3 must be cleaned
 
   // preserve user-defined \n newlines
   static const std::regex new_line(R"(\n)");

--- a/Utilities/Parameters.h
+++ b/Utilities/Parameters.h
@@ -1245,7 +1245,7 @@ public:
         build_string << std::fixed << workingParameterName << " = "
                      << workingValue.first;
 
-        build_string << " @@@#(" << workingValue.second << ") "
+        build_string << " @@@# (" << workingValue.second << ") "
                      << (*parameterDocumentation)[p.first];
         sorted_parameters[workingCategory].push_back(build_string.str());
       }

--- a/Utilities/Parameters.h
+++ b/Utilities/Parameters.h
@@ -1245,7 +1245,7 @@ public:
         build_string << std::fixed << workingParameterName << " = "
                      << workingValue.first;
 
-        build_string << " @@@# (" << workingValue.second << ") "
+        build_string << " @@@#(" << workingValue.second << ") "
                      << (*parameterDocumentation)[p.first];
         sorted_parameters[workingCategory].push_back(build_string.str());
       }


### PR DESCRIPTION
Basically makes layout in Parameter files cleaner. If parameter name goes over the commentIndent, comment is chopped. If parameter name goes over maxLineLength, the comment is started on the following line.

More lines changed than strictly necessary, but it's only clean up.