### PR TITLE
Enhancement simple optimizer cull by range

### DIFF
--- a/Optimizer/SimpleOptimizer/SimpleOptimizer.h
+++ b/Optimizer/SimpleOptimizer/SimpleOptimizer.h
@@ -43,6 +43,7 @@ public:
 
   static std::shared_ptr<ParameterLink<double>> cullBelowPL;
   static std::shared_ptr<ParameterLink<double>> cullRemapPL;
+  static std::shared_ptr<ParameterLink<bool>> cullByRangePL;
 
   std::string selectionMethod;
   int numberParents;
@@ -57,6 +58,10 @@ public:
   int selfCount;
   int eliteCount;
   int surviveCount;
+
+  double cullBelow;
+  double cullRemap;
+  bool cullByRange;
 
   double aveScore;
   double maxScore;


### PR DESCRIPTION
add cullRangeByRange parameter to simple optimizer - this allows cull to be relative to min and max score (when 1), or rank within population, i.e. .9 = best 10% of population (when 0, default value).