### PR TITLE
nth_element instead of sort

### DIFF
--- a/Optimizer/SimpleOptimizer/SimpleOptimizer.cpp
+++ b/Optimizer/SimpleOptimizer/SimpleOptimizer.cpp
@@ -175,9 +175,11 @@ void SimpleOptimizer::optimize(std::vector<std::shared_ptr<Organism>> &populatio
 		cullBelowScore = minScore + ((maxScore - minScore) * cullBelow);
 	} else { // cull not by range, but by rank position
 		auto sortedScores = scores;
-		std::sort(sortedScores.begin(), sortedScores.end());
-		cullBelowScore = sortedScores[sortedScores.size()
-			- static_cast<int>(((static_cast<double>(sortedScores.size())) * (1.0 - cullBelow)) + 1)];
+        auto cull_index = cullBelow * sortedScores.size() - 1;
+        std::nth_element(std::begin(sortedScores),
+                       std::begin(sortedScores) + cull_index,
+                       std::end(sortedScores));
+        cullBelowScore = sortedScores[cull_index];
 		
 		/* uncomment to see all scores
 		for (auto ss : sortedScores) {


### PR DESCRIPTION
Only the nth element is needed to decide cullBelow, which is a linear algorithm. Doing a sort before indexing into the appropriate position is linearithmic, which is not good in a hot path of the optimiser.

For #224 