### PR TITLE
Lexicase edits

### DIFF
--- a/Optimizer/LexicaseOptimizer/LexicaseOptimizer.cpp
+++ b/Optimizer/LexicaseOptimizer/LexicaseOptimizer.cpp
@@ -47,8 +47,8 @@ Parameters::register_parameter("OPTIMIZER_LEXICASE-epsilonByRange", false,
 	"\nif false, epsilon will be relative to organism ranks"
 	"\n  i.e. keep (best current keepers * epsilon) organisms");
 
-std::shared_ptr<ParameterLink<int>> LexicaseOptimizer::tournamentSizePL = 
-Parameters::register_parameter("OPTIMIZER_LEXICASE-tournamentSize", -1,
+std::shared_ptr<ParameterLink<int>> LexicaseOptimizer::poolSizePL = 
+Parameters::register_parameter("OPTIMIZER_LEXICASE-poolSize", -1,
 	"number of organisms used when selecting parent(s) in the lexicase algorithm, -1 indicates to use entire population");
 
 std::shared_ptr<ParameterLink<bool>> LexicaseOptimizer::recordOptimizeValuesPL = 
@@ -81,7 +81,7 @@ LexicaseOptimizer::LexicaseOptimizer(std::shared_ptr<ParametersTable> PT_)
 
 	epsilon = epsilonPL->get(PT);
 	epsilonByRange = epsilonByRangePL->get(PT);
-	tournamentSize = tournamentSizePL->get(PT);
+	poolSize = poolSizePL->get(PT);
 	nextPopSizeFormula = stringToMTree(nextPopSizePL->get(PT));
 	numberParents = numberParentsPL->get(PT);
 	recordOptimizeValues = recordOptimizeValuesPL->get(PT);
@@ -218,7 +218,7 @@ void LexicaseOptimizer::optimize(
       for (size_t fIndex = 0; fIndex < optimizeFormulasMTs.size(); fIndex++)
         population[i]->dataMap.set(scoreNames[fIndex], scores[fIndex][i]);
 
-  tournamentSize = tournamentSize == -1 ? population.size() : tournamentSize;
+  poolSize = poolSize == -1 ? population.size() : poolSize;
 
 
   auto nextPopulationTargetSize = nextPopSizeFormula->eval(PT)[0];
@@ -237,7 +237,7 @@ void LexicaseOptimizer::optimize(
         std::vector<std::shared_ptr<Organism>> parents;
         std::generate_n(std::back_inserter(parents), numberParents, [&] {
           return population[lexiSelect(
-              random_iota(tournamentSize, population.size()))];
+              random_iota(poolSize, population.size()))];
         });
         return parents[0]->makeMutatedOffspringFromMany(parents);
       });

--- a/Optimizer/LexicaseOptimizer/LexicaseOptimizer.h
+++ b/Optimizer/LexicaseOptimizer/LexicaseOptimizer.h
@@ -23,7 +23,7 @@ public:
 	static std::shared_ptr<ParameterLink<std::string>> optimizeFormulaNamesPL;
 	static std::shared_ptr<ParameterLink<double>> epsilonPL;
 	static std::shared_ptr<ParameterLink<bool>> epsilonByRangePL;
-	static std::shared_ptr<ParameterLink<int>> tournamentSizePL;
+	static std::shared_ptr<ParameterLink<int>> poolSizePL;
 	static std::shared_ptr<ParameterLink<std::string>> nextPopSizePL;
 	static std::shared_ptr<ParameterLink<int>> numberParentsPL;
 	static std::shared_ptr<ParameterLink<bool>> recordOptimizeValuesPL;
@@ -33,7 +33,7 @@ public:
 	bool scoresHaveDelta = false;
 	double epsilon;
 	bool epsilonByRange;
-	int tournamentSize;
+	int poolSize;
 
 	std::shared_ptr<Abstract_MTree> nextPopSizeFormula;
 	int numberParents;


### PR DESCRIPTION
Edits for #221 
Transposes the scores 2D vector. Makes element access more natural, as illustrated in one loop.

This does the change the results, though not qualitatively. Perhaps due to the order in which scores are computed. Not sure if this is a bug though.