### PR TITLE
Added public attributes to Organism

### DIFF
--- a/Organism/Organism.h
+++ b/Organism/Organism.h
@@ -51,6 +51,10 @@ public:
   std::unordered_set<int>
       snapshotAncestors; // like ancestors, but for snapshot files.
 
+  int orig_ID; // the original ID of the organism if it was loaded from a file, -1 otherwise
+  int orig_update; // the update at which the organism was saved, if it was
+                   // loaded from a file, -1 otherwise
+				   
   int ID;
   int timeOfBirth; // the time this organism was made
   int timeOfDeath; // the time this organism stopped being alive (this organism

--- a/main.cpp
+++ b/main.cpp
@@ -391,6 +391,10 @@ constructAllGroupsFrom(const std::shared_ptr<AbstractWorld> &world,
       auto newOrg =
           std::make_shared<Organism>(progenitor, newGenomes, newBrains, PT);
 
+      newOrg->orig_ID = org.first < 0 ? -1 : std::stol(org.second["ID"]);
+      newOrg->orig_update =
+          org.first < 0 ? -1 : std::stol(org.second["update"]);
+
       // add new organism to population
       population.push_back(newOrg);
     }


### PR DESCRIPTION
From #257 now Organism has two additional public data members that are -1, unless they are loaded from file, in which case, they have the corresponding ID and update from the loaded file.