### PR TITLE
change to Default Archivst so that update is saved in data files

### DIFF
--- a/Archivist/DefaultArchivist.cpp
+++ b/Archivist/DefaultArchivist.cpp
@@ -239,7 +239,8 @@ void DefaultArchivist::saveSnapshotData(
         population[0]->dataMap.getKeys(); // get all keys from the valid orgs
                                           // dataMap (all orgs should have the
                                           // same keys in their dataMaps)
-    files_["snapshotData"].push_back("snapshotAncestors");
+	files_["snapshotData"].push_back("snapshotAncestors");
+	files_["snapshotData"].push_back("update");
   }
 
 


### PR DESCRIPTION
This fixes a long standing bug (which only now came to light) where 'update' was not being saved in Default Archivist snapshot files. 'Update' is now being saved in these files.