### PR TITLE
Remove log2 and pow declarations in neurocorrelates

### DIFF
--- a/Analyze/neurocorrelates.cpp
+++ b/Analyze/neurocorrelates.cpp
@@ -7,7 +7,8 @@ using std::vector;
 using std::map; using std::pair; 
 #include <algorithm> 
 using std::copy; using std::min; using std::max; 
-#include <math.h>
+#include <cmath>
+using std::log2; using std::pow;
 #include <iostream>
 using std::cout; using std::endl;
 

--- a/Analyze/neurocorrelates.cpp
+++ b/Analyze/neurocorrelates.cpp
@@ -8,7 +8,6 @@ using std::map; using std::pair;
 #include <algorithm> 
 using std::copy; using std::min; using std::max; 
 #include <math.h>
-using std::log2; using std::pow; 
 #include <iostream>
 using std::cout; using std::endl;
 


### PR DESCRIPTION
Fixes #264 by removing the line declaring log2 and pow as members of std namespace. `#include <math.h>` takes care of these declarations and the feature should work as before. 