### PR TITLE
changed regex for compliance on new mac clang whitespacing definitions

### DIFF
--- a/Utilities/Parameters.cpp
+++ b/Utilities/Parameters.cpp
@@ -293,11 +293,7 @@ Parameters::readParametersFile(const std::string &file_name) {
       //std::regex name_value_pair(R"(^\s*([\S]+)\s*=\s*(\S?.*\S)\s*$)");
       std::regex name_value_pair(R"(^\s*([-\w:]+)\s*=(\s*.*\s*)$)");
       std::smatch m;
-      std::cout << "before regex" << std::endl;
-      std::cout << "line: " << line << std::endl;
       if (std::regex_match(line, m, name_value_pair)) {
-      std::cout << "inside regex" << std::endl;
-      std::cout << "m: " << m[1].str() << std::endl;
         auto name = name_space_name;
         name.append((category_name.empty() ? "" : (category_name + "-")))
             .append(m[1].str());

--- a/Utilities/Parameters.cpp
+++ b/Utilities/Parameters.cpp
@@ -291,9 +291,13 @@ Parameters::readParametersFile(const std::string &file_name) {
 
     {
       //std::regex name_value_pair(R"(^\s*([\S]+)\s*=\s*(\S?.*\S)\s*$)");
-      std::regex name_value_pair(R"(^\s*([\S]+)\s*=(\s*.*\s*)$)");
+      std::regex name_value_pair(R"(^\s*([-\w:]+)\s*=(\s*.*\s*)$)");
       std::smatch m;
+      std::cout << "before regex" << std::endl;
+      std::cout << "line: " << line << std::endl;
       if (std::regex_match(line, m, name_value_pair)) {
+      std::cout << "inside regex" << std::endl;
+      std::cout << "m: " << m[1].str() << std::endl;
         auto name = name_space_name;
         name.append((category_name.empty() ? "" : (category_name + "-")))
             .append(m[1].str());


### PR DESCRIPTION
Clang update October 2018 has a special definition of whitespacing vs non-whitespacing that broke a regex. This reverts and and patches for compliance.
namespace under category headings still does not work, must be fully qualified.