### PR TITLE
changed behaviour and usage message

### DIFF
--- a/Global.cpp
+++ b/Global.cpp
@@ -21,10 +21,10 @@ std::shared_ptr<ParameterLink<int>> Global::updatesPL =
                                    "how long the program will run");
 std::shared_ptr<ParameterLink<std::string>> Global::initPopPL =
     Parameters::register_parameter(
-        "GLOBAL-initPop", std::string("MASTER = default 100"),
+        "GLOBAL-initPop", std::string("default 100"),
         "initial population to start MABE (if it's .plf syntax it will be "
-        "parsed as such. If it's a file name with .plf that population loader "
-        "file is parsed");
+        "parsed as if preceded by \"MASTER = \". If it's a file name with .plf "
+        "that population loader file is parsed");
 std::shared_ptr<ParameterLink<std::string>> Global::modePL =
     Parameters::register_parameter(
         "GLOBAL-mode", std::string("run"),

--- a/Utilities/Loader.cpp
+++ b/Utilities/Loader.cpp
@@ -44,7 +44,7 @@ std::vector<std::pair<OrgID, OrgAttributesMap>> Loader::loadPopulation(const std
   static const std::regex plf_file(R"(.*\.plf)");
   std::string all_lines = std::regex_match(loader_option, plf_file)
                        ? loadFromFile(loader_option)
-                       : loader_option;
+                       : "MASTER = " + loader_option;
 
   // replace all filenames (expanded or otherwise) with temporary tokens
   all_lines = findAndGenerateAllFiles(all_lines);


### PR DESCRIPTION
Change behaviour of initPop parameter. The "MASTER = " piece of .plf syntax is now implicit, and cannot be specified. 
Default argument of initPop, and usage message is also updated.