### PR TITLE
hot fix to address quotes on strings. Quotes were not be added in all…

### DIFF
--- a/Brain/MarkovBrain/MarkovBrain.cpp
+++ b/Brain/MarkovBrain/MarkovBrain.cpp
@@ -253,10 +253,10 @@ DataMap MarkovBrain::getStats(std::string &prefix) {
     nextNodesConnectionsList.push_back(nextNodesConnections[i]);
   }
   dataMap.set(prefix + "markovBrain_nodesConnections", nodesConnectionsList);
-  dataMap.setOutputBehavior(prefix + "nodesConnections", DataMap::LIST);
+  dataMap.setOutputBehavior(prefix + "markovBrain_nodesConnections", DataMap::LIST);
   dataMap.set(prefix + "markovBrain_nextNodesConnections",
               nextNodesConnectionsList);
-  dataMap.setOutputBehavior(prefix + "nextNodesConnections", DataMap::LIST);
+  dataMap.setOutputBehavior(prefix + "markovBrain_nextNodesConnections", DataMap::LIST);
 
   return dataMap;
 }

--- a/Genome/CircularGenome/CircularGenome.cpp
+++ b/Genome/CircularGenome/CircularGenome.cpp
@@ -798,24 +798,24 @@ void CircularGenome<unsigned char>::loadGenomeFile(string fileName, vector<std::
 template<class T>
 std::string CircularGenome<T>::genomeToStr() {
 	std::stringstream ss;
-	ss << "\"";
+	ss << "";
 
 	for (size_t i = 0; i < sites.size()-1; i++) {
 		ss << sites[i] << FileManager::separator;
 	}
-	ss << sites[sites.size() - 1] << "\"";
+	ss << sites[sites.size() - 1];
 	return ss.str();
 }
 
 template<>
 std::string CircularGenome<unsigned char>::genomeToStr() {
 	std::stringstream ss;
-	ss << "\"";
+	ss << "";
 
 	for (size_t i = 0; i < sites.size() - 1; i++) {
 		ss << (int)sites[i] << FileManager::separator;
 	}
-	ss << (int)sites[sites.size() - 1] << "\"";
+	ss << (int)sites[sites.size() - 1] << "";
 	return ss.str();
 }
 

--- a/Genome/MultiGenome/Chromosome/TemplatedChromosome.cpp
+++ b/Genome/MultiGenome/Chromosome/TemplatedChromosome.cpp
@@ -280,8 +280,8 @@ template <> void TemplatedChromosome<bool>::fillRandom(int length) {
   }
   sites.resize(length);
   for (int i = 0; i < length; i++) {
-    std::cout << "alphabetSize: " << alphabetSize << "   "
-         << Random::getDouble(alphabetSize) << std::endl;
+    //std::cout << "alphabetSize: " << alphabetSize << "   "
+    //     << Random::getDouble(alphabetSize) << std::endl;
     sites[i] = (bool)((int)Random::getDouble(alphabetSize));
   }
 }

--- a/Genome/MultiGenome/MultiGenome.cpp
+++ b/Genome/MultiGenome/MultiGenome.cpp
@@ -545,12 +545,12 @@ DataMap MultiGenome::getStats(std::string& prefix) {
 DataMap MultiGenome::serialize(std::string& name) {
 	DataMap serialDataMap;
 
-	std::string chromosomeLengths = "\"";
+	std::string chromosomeLengths = "";
 	for (size_t c = 0; c < chromosomes.size(); c++) {
 		chromosomeLengths += std::to_string(chromosomes[c]->size()) + ",";
 	}
 	chromosomeLengths.pop_back();
-	chromosomeLengths += "\"";
+	chromosomeLengths += "";
 	serialDataMap.set(name + "_chromosomeLengths", chromosomeLengths);
 	serialDataMap.set(name + "_sites", genomeToStr());
 	return serialDataMap;
@@ -647,13 +647,13 @@ void MultiGenome::loadGenomeFile(std::string fileName, std::vector<std::shared_p
 
 // convert a chromosome to a string
 std::string MultiGenome::genomeToStr() {
-	std::string S = "\"";
+	std::string S = "";
 
 	for (size_t c = 0; c < chromosomes.size(); c++) {
 		S.append(chromosomes[c]->chromosomeToStr() + FileManager::separator);
 	}
-	S.pop_back(); // clip off the traialing separator
-	S.append("\"");
+	S.pop_back(); // clip off the trailing separator
+	S.append("");
 	return S;
 }
 

--- a/Utilities/Data.cpp
+++ b/Utilities/Data.cpp
@@ -109,9 +109,13 @@ void DataMap::constructHeaderAndDataStrings(std::string &headerStr, std::string 
       } 
 
       if (aveOnly) {
-        if (typeOfKey == STRING || typeOfKey == STRINGSOLO) OB = NO_OUTPUT;
-        else OB &= (AVE | FIRST); // if aveOnly, only output AVE on the entries
-                                 // that have been set for AVE
+		  if (typeOfKey == STRING || typeOfKey == STRINGSOLO) {
+			  OB = NO_OUTPUT;
+		  }
+		  else {
+			  OB &= (AVE | FIRST); // if aveOnly, only output AVE on the entries
+								 // that have been set for AVE
+		  }
       }
 
       if (OB & FIRST) { // save first (only?) element in vector with key as
@@ -151,9 +155,9 @@ void DataMap::constructHeaderAndDataStrings(std::string &headerStr, std::string 
         }
         if (typeOfKey == STRING || typeOfKey == STRINGSOLO) {
           if (!getStringVector(i).empty()) {
-            dataStr += FileManager::separator + getStringVector(i)[0];
+            dataStr += FileManager::separator + (std::string)"\"" + getStringVector(i)[0] + (std::string)"\"";
           } else {
-            dataStr += '0';
+            dataStr += (std::string)"\"0\"";
             std::cout << "  WARNING!! In DataMap::constructHeaderAndDataStrings :: "
                     "while getting value for FIRST with key \""
                  << i << "\" vector is empty!" << std::endl;
@@ -164,8 +168,7 @@ void DataMap::constructHeaderAndDataStrings(std::string &headerStr, std::string 
         headerStr += FileManager::separator + i + "_AVE";
         dataStr += FileManager::separator + std::to_string(getAverage(i));
       }
-      if (OB &
-          VAR) { // key_VAR = variance of vector (will error if of type string!)
+      if (OB & VAR) { // key_VAR = variance of vector (will error if of type string!)
         headerStr += FileManager::separator + i + "_VAR";
         dataStr += FileManager::separator + std::to_string(getVariance(i));
       }
@@ -181,10 +184,9 @@ void DataMap::constructHeaderAndDataStrings(std::string &headerStr, std::string 
         std::cout << "  WARNING OUTPUT METHOD STDERR IS HAS YET TO BE WRITTEN!"
              << std::endl;
       }
-      if (OB &
-          LIST) { // key_LIST = save all elements in vector in csv list format
+      if (OB & LIST) { // key_LIST = save all elements in vector in csv list format
         headerStr += FileManager::separator + i + "_LIST";
-        dataStr += FileManager::separator + getStringOfVector(i);
+        dataStr += FileManager::separator + (std::string)"\"" + getStringOfVector(i) + (std::string)"\"";
       }
     }
     headerStr.erase(headerStr.begin()); // clip off the leading separator

--- a/Utilities/Data.h
+++ b/Utilities/Data.h
@@ -575,7 +575,7 @@ public:
                                                        // a dataMap with "key" -
                                                        // if not already string,
                                                        // will be converted
-    std::string returnString = "\"";
+    std::string returnString = "";
     dataMapType typeOfKey = findKeyInData(key);
     if (typeOfKey == NONE) {
       std::cout << "  In DataMap::GetString() :: key \"" << key
@@ -603,7 +603,7 @@ public:
     if (returnString.size() > 2) { // if vector was not empty
       returnString.pop_back();     // remove trailing ","
     }
-    returnString += "\"";
+    returnString += "";
     return returnString;
   }
 


### PR DESCRIPTION
… casses to strings and lists. This required fixes in other modules (mostly genome).

note: this fix adds quotes when a string or any list is saved from datamap. As a result, genomes must no longer add quotes - to avoid double quotes.