### PR TITLE
Fixed error message resulting from confusing parsing

### DIFF
--- a/pythonTools/mq_conditions.txt
+++ b/pythonTools/mq_conditions.txt
@@ -47,6 +47,7 @@ EXECUTABLE = ./mabe
 #EXECUTABLE = mabe.exe
 
 -----
+# comma separate the mail type list ex: FAIL,END,REQUEUE
 
 # HPCC
 HPCC_LONGJOB = FALSE
@@ -56,5 +57,3 @@ HPCC_PARAMETERS = #SBATCH --cpus-per-task=1
 HPCC_PARAMETERS = #SBATCH --time=03:50:00
 HPCC_PARAMETERS = #SBATCH --mem=2G
 HPCC_PARAMETERS = #SBATCH --mail-type=FAIL
-#comma sep the mail type list ex: FAIL,END,REQUEUE
-


### PR DESCRIPTION
Having a commented-out line after the HPCC_PARAMETERS and #SBATCH tags was causing vim to throw an error when opening up the file, because it thought we were trying to declare a parameter called FAIL,END,REQUIRE.

The error did not actually affect anything (jobs ran as requested), but repeatedly seeing this error was annoying me, so i moved the comment before the parameters. 