### PR TITLE
Fix for the MarkovBrains IO reset issue

### DIFF
--- a/Brain/MarkovBrain/MarkovBrain.cpp
+++ b/Brain/MarkovBrain/MarkovBrain.cpp
@@ -92,11 +92,13 @@ void MarkovBrain::resetBrain() {
 	}
 }
 void MarkovBrain::resetInputs() {
+	AbstractBrain::resetInputs();
 	for (int i = 0; i < nrInputValues; i++) {
 		nodes[i] = 0.0;
 	}
 }
 void MarkovBrain::resetOutputs() {
+	AbstractBrain::resetOutputs();
 	for (int i = 0; i < nrOutputValues; i++) {
 		nodes[nrInputValues + i] = 0.0;
 	}


### PR DESCRIPTION
Prior to this commit, Markov Brains did not reset IO buffers
inherited from AbstractBrain upon the call to reset(). The buffers
were used by Markov Brains and the state they retained affected
their behavior.

modified:   Brain/MarkovBrain/MarkovBrain.cpp