### PR TITLE
MarkovBrain execution time optimization

### DIFF
--- a/Utilities/Utilities.h
+++ b/Utilities/Utilities.h
@@ -305,12 +305,12 @@ template <typename Type>
 inline int vectorToBitToInt(const std::vector<Type> &nodes,
                             const std::vector<int> &nodeAddresses,
                             bool reverseOrder = false) {
-  auto node_addresses = nodeAddresses;
-  if (reverseOrder)
-    std::reverse(node_addresses.begin(), node_addresses.end());
-  return std::accumulate(
-      node_addresses.begin(), node_addresses.end(), 0,
-      [&nodes](int result, int na) { return result * 2 + Bit(nodes.at(na)); });
+	if(reverseOrder)
+		return std::accumulate(nodeAddresses.crbegin(), nodeAddresses.crend(), 0,
+			[&nodes](int result, int na) { return result * 2 + Bit(nodes.at(na)); });
+	else
+		return std::accumulate(nodeAddresses.cbegin(), nodeAddresses.cend(), 0,
+			[&nodes](int result, int na) { return result * 2 + Bit(nodes.at(na)); });
 }
 
 template <typename Type>


### PR DESCRIPTION
In the vectorToBitToInt utility function a temporary container
in which the node addresses were stored in appropriate order
is replaced by iterating over the original container in
appropriate direction. Memory reallocation is thus avoided.

This function is called at every call of DeterministcGate::update().
In the codes that rely heavily on MarkovBrains' deterministic gate,
this optimization cuts execution time approximately by a quarter.

	modified:   Utilities/Utilities.h