### PR TITLE
change the the AbstractBrain signiture to require a PT (as apposed to…

### DIFF
--- a/Brain/AbstractBrain.h
+++ b/Brain/AbstractBrain.h
@@ -105,7 +105,7 @@ public:
          << std::endl
          << "Exiting." << std::endl;
     exit(1);
-    return makeCopy();
+    return makeCopy(PT);
   }
 
   // Make a brain like the brain that called this function, using genomes and
@@ -216,7 +216,7 @@ public:
   //	}
 
   virtual std::shared_ptr<AbstractBrain>
-  makeCopy(std::shared_ptr<ParametersTable> PT_ = nullptr) {
+  makeCopy(std::shared_ptr<ParametersTable> PT_) {
     std::cout << "ERROR IN AbstractBrain::makeCopy() - You are using the abstract "
             "copy constructor for brains. You must define your own"
          << std::endl;

--- a/World/BerryWorld/BerryWorld.cpp
+++ b/World/BerryWorld/BerryWorld.cpp
@@ -1901,7 +1901,7 @@ void BerryWorld::runWorld(std::map<std::string, std::shared_ptr<Group>> &groups,
           newHarvester->isClone = true;
           newHarvester->org =
               harvesters[i]->org; // provide access to org though harvester
-          newHarvester->brain = harvesters[i]->brain->makeCopy();
+          newHarvester->brain = harvesters[i]->brain->makeCopy(harvesters[i]->brain->PT);
           // set inital location
           auto pick =
               Random::getIndex(tempValidSpaces.size()); // get a random index


### PR DESCRIPTION
change the AbstractBrain signature to require a PT (as opposed to none defaulting to nullPtr). This should have happened when parameters were changed to require a PT. This issue surfaced on a direct encoded brains makeCopy used in a world.

This will cause an issue anywhere makeCopy is being used without a PT. This is a simple fix though.
Berryworld (because of possible clones) will be included in this pull request.