### PR TITLE
added cmake out of src workflow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.15.5)
+option(BUILD_TYPE Debug)
+set(CMAKE_BUILD_TYPE ${BUILD_TYPE})
+
+set(EXE mabe)
+project(${EXE})
+
+## set path to cmake modules for finding mkl, etc.
+set(CMAKE_MODULE_PATH ${CMAKE_MODULEPATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
+
+# OS-specific alterations
+if (MSYS OR MINGW)
+  # msys2 environment struggles with compiler detection
+  message(STATUS "detected platform: msys/mingw on windows")
+  set(CMAKE_C_COMPILER gcc)
+  set(CMAKE_CXX_COMPILER g++)
+endif()
+if (MSVC OR WIN32)
+  message(STATUS "detected platform: visual studio on windows")
+endif()
+if (UNIX AND NOT APPLE)
+  message(STATUS "detected platform: linux")
+endif()
+if (APPLE)
+  message(STATUS "detected platform: apple")
+endif()
+
+# read buildOptions
+# produce modules.h, cmake_auto_injection.txt
+message(STATUS "building modules.h...")
+find_package(Python3 COMPONENTS Interpreter)
+if (NOT Python3_FOUND)
+  message(FATAL_ERROR " Python3 required for pythonTools/mbuild.py functionality")
+endif()
+execute_process(
+  COMMAND ${Python3_EXECUTABLE} pythonTools/mbuild.py -nc
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+
+add_executable(${EXE} main.cpp)
+
+# include cmake_auto_injection.txt (mabe build config)
+include(cmake_auto_injection.txt)
+
+## set standard to c++17
+set(CMAKE_CXX_STANDARD 17)
+target_compile_features(${EXE} PRIVATE cxx_std_17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+

--- a/buildOptions.txt
+++ b/buildOptions.txt
@@ -30,3 +30,9 @@
   + SSwD
   * LODwAP
 
+# additional cmake configurations may be passed here
+# as a space separated list of files
+# they will be concatenated into 'cmake_auto_injection.txt'
+# and read during the configuration process
+
+additional_cmake_configs


### PR DESCRIPTION
First part of a deprecation of mbuild.py project generation.
The functionality has been replaced by a cmake out of source workflow:
1) git clone mabe (shorthand)
2) edit mabe/buildOptions.txt
3) mkdir build
4) cmake ../mabe -G <project type>
where makefiles are default, and your system may support: Visual Studio, XCode, CodeBlocks, Ninja, and others.

Benefits:
* Out of source workflow to not dirty the repo clone.
* A more standard software practice that is no more difficult than we had before.
* We don't have to support project generation code anymore.
* buildOptions now allows adding custom cmake fragments as filenames, which opens the door to easily adding external libraries (ex: 3d graphics, fast linear algebra, etc.)

Note, for Visual Studio, you will need to be in a Visual Studio Environment command prompt (it's in the start menu somewhere - type Visual Studio)

Tested on Windows 10, OSX Catalina, HPCC, MSYS2/MinGW.

Why didn't we do this before? Because only in the last year did Visual Studio's cmake support become decent.