### PR TITLE
Bugfix genome circular indel mutation

### DIFF
--- a/Genome/CircularGenome/CircularGenome.cpp
+++ b/Genome/CircularGenome/CircularGenome.cpp
@@ -34,7 +34,7 @@ std::shared_ptr<ParameterLink<int>> CircularGenomeParameters::mutationCrossCount
 
 std::shared_ptr<ParameterLink<double>> CircularGenomeParameters::mutationPointOffsetRatePL = Parameters::register_parameter("GENOME_CIRCULAR-mutationPointOffsetRate", 0.0, "per site point offset mutation rate (site changes in range (+/-)mutationPointOffsetRange)");
 std::shared_ptr<ParameterLink<double>> CircularGenomeParameters::mutationPointOffsetRangePL = Parameters::register_parameter("GENOME_CIRCULAR-mutationPointOffsetRange", 1.0, "range of PointOffset mutation");
-std::shared_ptr<ParameterLink<bool>> CircularGenomeParameters::mutationPointOffsetUniformPL = Parameters::register_parameter("GENOME_CIRCULAR-mutationPointOffsetUniform", true, "if true, offset will be from a uniform distribution, if false, from a normal distribution (mean = 0, std_dev = range)");
+std::shared_ptr<ParameterLink<bool>> CircularGenomeParameters::mutationPointOffsetUniformPL = Parameters::register_parameter("GENOME_CIRCULAR-mutationPointOffsetUniform", true, "if true, offset will be from a uniform distribution, if false, from a normal distribution (where mean is 0 and std_dev is mutationPointOffsetRange)");
 
 
 // constructor

--- a/Genome/CircularGenome/CircularGenome.cpp
+++ b/Genome/CircularGenome/CircularGenome.cpp
@@ -680,16 +680,37 @@ void CircularGenome<T>::mutate() {
 		if (copyFirst) {
 			// if copy before delete
 			// copy a portion of the genome into segment
-			int segmentStart = Random::getIndex((int)sites.size() - segmentSize); // where to copy from
-			int deleteStart = Random::getIndex((int)sites.size() - segmentSize); // where to delete from
+			int segmentStart = Random::getInt((int)sites.size() - segmentSize); // where to copy from
+			int deleteStart = Random::getInt((int)sites.size() - segmentSize); // where to delete from
 			segment.clear();
 			segment.insert(segment.begin(), it + segmentStart, it + segmentStart + segmentSize);
+
+/*
+            std::cout << "\ncopyFirst\ngenome: ";
+			for (auto s : sites) {
+				std::cout << s << " ";
+			}
+			std::cout << "   size: " << segmentSize << "    segmentStart: " << segmentStart << "    deleteStart: " << deleteStart << std::endl;
+			std::cout << std::endl << "segment: ";
+			for (auto s : segment) {
+				std::cout << s << " ";
+			}
+			std::cout << std::endl;
+*/
+
 			// delete a portion of the genome of the same size
 			sites.erase(it + deleteStart, it + deleteStart + segmentSize);
+
+/*
+			std::cout << "\ngenome after delete: ";
+			for (auto s : sites) {
+				std::cout << s << " ";
+			}
+*/
 			// insert the copied sites back into genome
 			if (insertMethod == 0) {
 				// copy to random location
-				sites.insert(it + Random::getIndex((int)sites.size()), segment.begin(), segment.end());
+				sites.insert(it + Random::getInt((int)sites.size()), segment.begin(), segment.end());
 			}
 			else if (insertMethod == 1) {
 				// replace deleted segment
@@ -702,22 +723,33 @@ void CircularGenome<T>::mutate() {
 				}
 				sites.insert(it + segmentStart, segment.begin(), segment.end());
 			}
+/*
+			std::cout << "\ngenome after insert: ";
+			for (auto s : sites) {
+				std::cout << s << " ";
+			}
+*/
 		}
 		else {
 			// delete before copy (deleted sites cannot be copied)
 			// delete a portion of the genome
-			int deleteStart = Random::getIndex((int)sites.size() - segmentSize); // where to delete from
+			int deleteStart = Random::getInt((int)sites.size() - segmentSize); // where to delete from
 			sites.erase(it + deleteStart, it + deleteStart + segmentSize);
 
+            if (segmentSize > sites.size()){
+                std::cout << "ERROR: in curlarGenome<T>::mutate(), segmentSize for indel is > then sites.size() after deletion!\nUse a larger genome relitive to Indel min/max.\nExiting!" << std::endl;
+                std::cout << "segmentSize = " << segmentSize << "  sites.size() after indel delete = " << (int)sites.size() << std::endl;
+                exit(1);
+            }
 			// copy a portion of the genome into segment
-			int segmentStart = Random::getIndex((int)sites.size() - segmentSize);
+			int segmentStart = Random::getInt((int)sites.size() - segmentSize);
 			segment.clear();
 			segment.insert(segment.begin(), it + segmentStart, it + segmentStart + segmentSize);
 
 			// insert the copied sites back into genome
 			if (insertMethod == 0) {
 				// copy to random location
-				sites.insert(it + Random::getIndex((int)sites.size()), segment.begin(), segment.end());
+				sites.insert(it + Random::getInt((int)sites.size()), segment.begin(), segment.end());
 			}
 			else if (insertMethod == 1) {
 				// replace deleted segment

--- a/Genome/CircularGenome/CircularGenome.h
+++ b/Genome/CircularGenome/CircularGenome.h
@@ -32,6 +32,7 @@ public:
 	static std::shared_ptr<ParameterLink<double>> mutationPointRatePL;
 	static std::shared_ptr<ParameterLink<double>> mutationPointOffsetRatePL;
 	static std::shared_ptr<ParameterLink<double>> mutationPointOffsetRangePL;
+    static std::shared_ptr<ParameterLink<bool>> mutationPointOffsetUniformPL;
 	static std::shared_ptr<ParameterLink<double>> mutationCopyRatePL;
 	static std::shared_ptr<ParameterLink<int>> mutationCopyMinSizePL;
 	static std::shared_ptr<ParameterLink<int>> mutationCopyMaxSizePL;


### PR DESCRIPTION
Primarily this fixes a bug where indel mutation on circular genome was not able to effect the last site in the genome (random getIndex was used rather than getInt). Also, this adds a new feature to allow for normal distribution of point mutation. 