### PR TITLE
removed writeDouble debug output

### DIFF
--- a/Genome/CircularGenome/CircularGenome.cpp
+++ b/Genome/CircularGenome/CircularGenome.cpp
@@ -261,9 +261,9 @@ void CircularGenome<T>::Handler::writeDouble(double value, double valueMin, doub
 		exit(1);
 	}
 	// old version: value = ((value - valueMin) / (valueMax - valueMin)) * genome->alphabetSize;
-	std::cout << value << "   " << valueMax << "   " << valueMin << " = ";
+	//std::cout << value << "   " << valueMax << "   " << valueMin << " = ";
 	value = ((value - valueMin) / (valueMax - valueMin)) * (genome->alphabetSize - 1.0);
-	std::cout << value << std::endl;
+	//std::cout << value << std::endl;
 	genome->sites[siteIndex] = (T)value;
 	advanceIndex();
 }


### PR DESCRIPTION
There was some cout left in CircularGenome writeDouble() method, so the screen was spammed with debug output at the start of a run.