### PR TITLE
add setAllInputs(vector<double>) and readAllOutputs() to AbstractBrai…

### DIFF
--- a/Brain/ANNBrain/ANNBrain.h
+++ b/Brain/ANNBrain/ANNBrain.h
@@ -81,8 +81,25 @@ public:
 	virtual std::unordered_set<std::string> requiredGenomes() override {
 		return {genomeNamePL->get(PT)};
 	}
-    inline void setInput(const int& inputAddress, const double& value);
-    inline double readInput(const int& inputAddress);
+	inline void setInput(const int& inputAddress, const double& value);
+
+
+	inline virtual void setAllInputs(const std::vector<double>& values) {
+		if (values.size() == nrInputValues) {
+			nodes[0] = values;
+		}
+		else {
+			std::cout << "in ANNBrain::setAllInputs() : Size of provided vector (" << values.size() << ") does not match number of brain inputs (" << nrInputValues << ").\nExiting"
+				<< std::endl;
+			exit(1);
+		}
+	}
+
+	inline virtual std::vector<double> readAllOutputs() {
+		return nodes[(int)nodes.size() - 1];
+	}
+
+	inline double readInput(const int& inputAddress);
     inline void setOutput(const int& outputAddress, const double& value);
     inline double readOutput(const int& outputAddress);
     virtual void getAllBrainStates(std::vector<double> &I, std::vector<double> &O, std::vector<double> &H) {

--- a/Brain/AbstractBrain.h
+++ b/Brain/AbstractBrain.h
@@ -171,6 +171,17 @@ public:
     }
   }
 
+  inline virtual void setAllInputs(const std::vector<double>& values) {
+      if (values.size() == nrInputValues) {
+          inputValues = values;
+      }
+      else {
+          std::cout << "in Brain::setAllInputs() : Size of provided vector ("<< values.size()<<") does not match number of brain inputs (" << nrInputValues << ").\nExiting"
+              << std::endl;
+          exit(1);
+      }
+  }
+
   inline virtual double readInput(const int &inputAddress) {
     if (inputAddress < nrInputValues) {
       return inputValues[inputAddress];
@@ -202,6 +213,10 @@ public:
            << std::endl;
       exit(1);
     }
+  }
+
+  inline virtual std::vector<double> readAllOutputs() {
+      return outputValues;
   }
 
   //	// converts the value of each value in nodes[] to bit and converts the

--- a/Brain/BiLogBrain/BiLogBrain.h
+++ b/Brain/BiLogBrain/BiLogBrain.h
@@ -44,6 +44,27 @@ public:
 
     inline double readOutput(const int &outputAddress) override;
 
+	inline virtual void setAllInputs(const std::vector<double>& values) {
+		if (values.size() == nrInputValues) {
+			for (int i = 0; i < nrInputValues; i++) {
+				nodes[N_Ins][i] = Bit(values[i]);
+			}
+		}
+		else {
+			std::cout << "in Brain::setAllInputs() : Size of provided vector (" << values.size() << ") does not match number of brain inputs (" << nrInputValues << ").\nExiting"
+				<< std::endl;
+			exit(1);
+		}
+	}
+
+	inline virtual std::vector<double> readAllOutputs() {
+		std::vector<double> returnVector;
+		for (auto v : nodes[N_Outs]) {
+			returnVector.push_back(static_cast<double>(v));
+		}
+		return returnVector;
+	}
+
     virtual void update() override;
 
 	////////////////////////////////////


### PR DESCRIPTION
adds access functions to brain input and output vectors. For brains that do not use inputValues and outputValues, these functions will need to be overridden (as is needed for set and read functions now).
override functions for ANN and BiLog are included in this pull request.